### PR TITLE
Fix #37: Add orphan option in checkout

### DIFF
--- a/src/main/groovy/org/ajoberstar/grgit/operation/CheckoutOp.groovy
+++ b/src/main/groovy/org/ajoberstar/grgit/operation/CheckoutOp.groovy
@@ -46,6 +46,18 @@ import org.eclipse.jgit.api.errors.GitAPIException
  * grgit.checkout(branch: 'new-branch', startPoint: 'any-branch', createBranch: true)
  * </pre>
  *
+ * <p>To checkout a new orphan branch starting at, but not tracking, the current HEAD.</p>
+ *
+ * <pre>
+ * grgit.checkout(branch: 'new-branch', orphan: true)
+ * </pre>
+ *
+ * <p>To checkout a new orphan branch starting at, but not tracking, a start point.</p>
+ *
+ * <pre>
+ * grgit.checkout(branch: 'new-branch', startPoint: 'any-branch', orphan: true)
+ * </pre>
+ *
  * See <a href="http://git-scm.com/docs/git-checkout">git-checkout Manual Page</a>.
  *
  * @since 0.1.0
@@ -66,25 +78,32 @@ class CheckoutOp implements Callable<Void> {
 	boolean createBranch = false
 
 	/**
-	 * If {@code createBranch} is {@code true}, start the new branch
+	 * If {@code createBranch} or {@code orphan} is {@code true}, start the new branch
 	 * at this commit.
 	 */
 	String startPoint
+
+	/**
+	 * {@code true} if the new branch is to be an orphan,
+	 * {@code false} (the default) otherwise
+	 */
+	boolean orphan = false
 
 	CheckoutOp(Repository repo) {
 		this.repo = repo
 	}
 
 	Void call() {
-		if (startPoint && !createBranch) {
-			throw new IllegalArgumentException('Cannot set a start point if createBranch is false.')
-		} else if (createBranch && !branch) {
+		if (startPoint && !createBranch && !orphan) {
+			throw new IllegalArgumentException('Cannot set a start point if createBranch and orphan are false.')
+		} else if ((createBranch || orphan) && !branch) {
 			throw new IllegalArgumentException('Must specify branch name to create.')
 		}
 		CheckoutCommand cmd = repo.jgit.checkout()
 		if (branch) { cmd.name = branch }
 		cmd.createBranch = createBranch
 		cmd.startPoint = startPoint
+		cmd.orphan = orphan
 		try {
 			cmd.call()
 			return null

--- a/src/test/groovy/org/ajoberstar/grgit/operation/CheckoutOpSpec.groovy
+++ b/src/test/groovy/org/ajoberstar/grgit/operation/CheckoutOpSpec.groovy
@@ -78,4 +78,32 @@ class CheckoutOpSpec extends SimpleGitOpSpec {
 		then:
 		thrown(IllegalArgumentException)
 	}
+
+	def 'checkout with existing branch and orphan true fails'() {
+		when:
+		grgit.checkout(branch: 'my-branch', orphan: true)
+		then:
+		thrown(GrgitException)
+	}
+
+	def 'checkout with non-existent branch and orphan true works'() {
+		when:
+		grgit.checkout(branch: 'orphan-branch', orphan: true)
+		then:
+		grgit.branch.current.fullName == 'refs/heads/orphan-branch'
+	}
+
+	def 'checkout with non-existent branch, orphan true, and startPoint works'() {
+		when:
+		grgit.checkout(branch: 'orphan-branch', orphan: true, startPoint: 'my-branch')
+		then:
+		grgit.branch.current.fullName == 'refs/heads/orphan-branch'
+	}
+
+	def 'checkout with no branch name and orphan true fails'() {
+		when:
+		grgit.checkout(orphan: true)
+		then:
+		thrown(IllegalArgumentException)
+	}
 }


### PR DESCRIPTION
As per the [JGit API](http://download.eclipse.org/jgit/site/3.5.0.201409260305-r/apidocs/org/eclipse/jgit/api/CheckoutCommand.html#setOrphan%28boolean%29), `setOrphan` is available since 3.3.
