### PR TITLE
adding CompileStatic to exception for strict compilers

### DIFF
--- a/src/main/groovy/org/ajoberstar/grgit/exception/GrgitException.groovy
+++ b/src/main/groovy/org/ajoberstar/grgit/exception/GrgitException.groovy
@@ -15,10 +15,12 @@
  */
 package org.ajoberstar.grgit.exception
 
+import groovy.transform.CompileStatic
 import groovy.transform.InheritConstructors
 
 /**
  * Generic exception for any failures in use of Grgit.
  */
 @InheritConstructors
+@CompileStatic
 class GrgitException extends RuntimeException {}


### PR DESCRIPTION
Adding `@CompileStatic` here so you can compile subprojects that don't want dynamic methods on exceptions.  (for example when I compile https://github.com/ajoberstar/gradle-git)