### PR TITLE
Fix link to Maven Center badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The Groovy way to use Git.
 
 [![Build Status](https://travis-ci.org/ajoberstar/grgit.png?branch=master)](https://travis-ci.org/ajoberstar/grgit)
 [![Maintainer Status](http://stillmaintained.com/ajoberstar/grgit.png)](http://stillmaintained.com/ajoberstar/grgit)
-[![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.ajoberstar/grgit/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.ajoberstar/grgit/badge.svg)
+[![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.ajoberstar/grgit/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.ajoberstar/grgit)
 
 ## What is this?
 


### PR DESCRIPTION
After the click badge was shown instead of the page with details about the latest version.

It seems that I made that a partially broken PR some time ago ;).