### PR TITLE
adding a very basic git describe command

### DIFF
--- a/src/main/groovy/org/ajoberstar/grgit/Grgit.groovy
+++ b/src/main/groovy/org/ajoberstar/grgit/Grgit.groovy
@@ -106,7 +106,7 @@ class Grgit {
 		clean: CleanOp, status: StatusOp, add: AddOp, remove: RmOp,
 		reset: ResetOp, apply: ApplyOp, pull: PullOp, push: PushOp,
 		fetch: FetchOp, checkout: CheckoutOp, log: LogOp, commit: CommitOp,
-		revert: RevertOp, merge: MergeOp
+		revert: RevertOp, merge: MergeOp, describe: DescribeOp
 	].asImmutable()
 
 	/**

--- a/src/main/groovy/org/ajoberstar/grgit/operation/DescribeOp.groovy
+++ b/src/main/groovy/org/ajoberstar/grgit/operation/DescribeOp.groovy
@@ -1,0 +1,43 @@
+package org.ajoberstar.grgit.operation
+import org.ajoberstar.grgit.Repository
+import org.ajoberstar.grgit.exception.GrgitException
+import org.eclipse.jgit.api.DescribeCommand
+import org.eclipse.jgit.api.errors.GitAPIException
+
+import java.util.concurrent.Callable
+
+/**
+ * Find the nearest tag reachable from HEAD. Returns an {@link String}}.
+ *
+ * <p>Find the most recent tag that is reachable from HEAD.  If the tag points to the commit, then only the tag is
+ * shown. Otherwise, it suffixes the tag name with the number of additional commits on top of the tagged object and the
+ * abbreviated object name of the most recent commit.</p>
+ *
+ * <pre>
+ * def description = grgit.description()
+ * </pre>
+ *
+ * See <a href="http://git-scm.com/docs/git-describe">git-describe Manual Page</a>.
+ *
+ * @see <a href="http://git-scm.com/docs/git-describe">git-describe Manual Page</a>
+ */
+class DescribeOp implements Callable<String> {
+    private final Repository repo
+    private final Object commit
+
+    DescribeOp(Repository repo){
+        this.repo = repo
+        this.commit = null
+    }
+
+    String call(){
+        DescribeCommand cmd = repo.jgit.describe()
+        try {
+            return cmd.call()
+        } catch (GitAPIException e) {
+            throw new GrgitException('Problem retrieving description.', e)
+        }
+
+    }
+}
+

--- a/src/test/groovy/org/ajoberstar/grgit/operation/DescribeOpSpec.groovy
+++ b/src/test/groovy/org/ajoberstar/grgit/operation/DescribeOpSpec.groovy
@@ -1,0 +1,26 @@
+package org.ajoberstar.grgit.operation
+
+import org.ajoberstar.grgit.fixtures.SimpleGitOpSpec
+
+
+class DescribeOpSpec extends SimpleGitOpSpec {
+    def setup() {
+        grgit.commit(message:"initial commit")
+        grgit.tag.add(name:"initial")
+    }
+
+    def 'with initial tag'() {
+        expect:
+        grgit.describe() == "initial"
+    }
+
+    def 'with additional commit'(){
+        when:
+        repoFile('1.txt') << '1'
+        grgit.add(patterns:['1.txt'])
+        grgit.commit(message:  "another commit")
+        then:
+        grgit.describe().startsWith("initial-1-")
+    }
+}
+


### PR DESCRIPTION
it only functions on the current HEAD, but that's the biggest use case

the jgit describe command is very limited option wise compared to cgit, so there isn't that much that can be done without implementing it separately  

initial stab at #39 