### PR TITLE
RemoteListOpSpec was failing, now it passes.

### DIFF
--- a/src/test/groovy/org/ajoberstar/grgit/fixtures/MultiGitOpSpec.groovy
+++ b/src/test/groovy/org/ajoberstar/grgit/fixtures/MultiGitOpSpec.groovy
@@ -31,7 +31,7 @@ class MultiGitOpSpec extends Specification {
 	Person person = new Person('Bruce Wayne', 'bruce.wayne@wayneindustries.com')
 
 	protected Grgit init(String name) {
-		File repoDir = tempDir.newFolder(name)
+		File repoDir = tempDir.newFolder(name).canonicalFile
 		Git git = Git.init().setDirectory(repoDir).call()
 		git.repo.config.with {
 			setString('user', null, 'name', person.name)


### PR DESCRIPTION
The problem occurred on Mac OS/X due to the way /var is mapped to /private/var.

Because of this mapping (it's a symbolic link) the "canonicalFile" method was returning /private/var in the test but /var was used in the test setup.  So, I added a call to "canonicalFile" in the test setup.  This problem may manifest itself on other platforms, too, so I believe this is the correct way to perform this test.