### PR TITLE
Merge enhancements

### DIFF
--- a/src/main/groovy/org/ajoberstar/grgit/operation/MergeOp.groovy
+++ b/src/main/groovy/org/ajoberstar/grgit/operation/MergeOp.groovy
@@ -58,6 +58,11 @@ class MergeOp implements Callable<Void> {
 	Object head
 
 	/**
+	 * The message to use for the merge commit
+	 */
+	String message
+
+	/**
 	 * How to handle the merge.
 	 */
 	Mode mode
@@ -76,6 +81,9 @@ class MergeOp implements Callable<Void> {
 			} else {
 				cmd.include(ref)
 			}
+		}
+		if (message) {
+			cmd.setMessage(message)
 		}
 		switch (mode) {
 			case Mode.ONLY_FF:

--- a/src/main/groovy/org/ajoberstar/grgit/operation/MergeOp.groovy
+++ b/src/main/groovy/org/ajoberstar/grgit/operation/MergeOp.groovy
@@ -69,8 +69,13 @@ class MergeOp implements Callable<Void> {
 	Void call() {
 		MergeCommand cmd = repo.jgit.merge()
 		if (head) {
-			def revstr = new ResolveService(repo).toRevisionString(head)
-			cmd.include(JGitUtil.resolveObject(repo, revstr))
+			def ref = repo.jgit.repository.getRef(head)
+			if (ref == null) {
+				def revstr = new ResolveService(repo).toRevisionString(head)
+				cmd.include(JGitUtil.resolveObject(repo, revstr))
+			} else {
+				cmd.include(ref)
+			}
 		}
 		switch (mode) {
 			case Mode.ONLY_FF:


### PR DESCRIPTION
This is to fix #93.

All the current specs still pass. I first attempt to get a ref which results in the correct merge message. If a ref is not found (a partial sha would cause this), then I fall back to the old way of doing things which resolves the sha of the commit instead of a ref.

While I was looking at the code, I also noticed the jgit allows a message to be passed to the merge command so I went ahead and added that here as well. It has no tests though so if you want I can remove it from this PR.