### PR TITLE
Update RemoteAddOp.groovy

### DIFF
--- a/src/main/groovy/org/ajoberstar/grgit/operation/RemoteAddOp.groovy
+++ b/src/main/groovy/org/ajoberstar/grgit/operation/RemoteAddOp.groovy
@@ -82,9 +82,7 @@ class RemoteAddOp implements Callable<Remote> {
 	@Override
 	Remote call() {
 		Config config = repository.jgit.repository.config
-		RemoteConfig currentConfig = RemoteConfig.getAllRemoteConfigs(config).find { it.name == name }) {
-			return it
-		}
+		RemoteConfig currentConfig = RemoteConfig.getAllRemoteConfigs(config).find { it.name == name }
 		
 		def toUri = { url -> new URIish(url) }
 		def toRefSpec = { spec -> new RefSpec(spec) }

--- a/src/main/groovy/org/ajoberstar/grgit/operation/RemoteAddOp.groovy
+++ b/src/main/groovy/org/ajoberstar/grgit/operation/RemoteAddOp.groovy
@@ -82,12 +82,13 @@ class RemoteAddOp implements Callable<Remote> {
 	@Override
 	Remote call() {
 		Config config = repository.jgit.repository.config
-		if (RemoteConfig.getAllRemoteConfigs(config).find { it.name == name }) {
-			throw new GrgitException("Remote $name already exists.")
+		RemoteConfig currentConfig = RemoteConfig.getAllRemoteConfigs(config).find { it.name == name }) {
+			return it
 		}
+		
 		def toUri = { url -> new URIish(url) }
 		def toRefSpec = { spec -> new RefSpec(spec) }
-		RemoteConfig remote = new RemoteConfig(config, name)
+		RemoteConfig remote = currentConfig ? currentConfig : new RemoteConfig(config, name)
 		if (url) { remote.addURI(toUri(url)) }
 		if (pushUrl) { remote.addPushURI(toUri(pushUrl)) }
 		remote.fetchRefSpecs = (fetchRefSpecs ?: ["+refs/heads/*:refs/remotes/$name/*"]).collect(toRefSpec)


### PR DESCRIPTION
Comment - If remote with given name already exists, its URIs are replaced with newly specified ones.

Is incorrect, doesn't actually replace with new ones.