### PR TITLE
Support more customization for ssh session, also disabling strict host key check #95

### DIFF
--- a/src/main/groovy/org/ajoberstar/grgit/auth/AuthConfig.groovy
+++ b/src/main/groovy/org/ajoberstar/grgit/auth/AuthConfig.groovy
@@ -57,6 +57,14 @@ import org.ajoberstar.grgit.exception.GrgitException
  * <ul>
  *     <li>{@code org.ajoberstar.grgit.auth.ssh.private=<path.to.private.key>}</li>
  * </ul>
+ * <p>
+ *   In order to add a non-standard session config,
+ *   use the following property.
+ * </p>
+ *
+ * <ul>
+ *     <li>{@code org.ajoberstar.grgit.auth.session.config.<key>=<value>}</li>
+ * </ul>
  *
  * <p>
  *   The following order is used to determine which authentication option
@@ -80,6 +88,7 @@ class AuthConfig {
 	static final String USERNAME_OPTION = 'org.ajoberstar.grgit.auth.username'
 	static final String PASSWORD_OPTION = 'org.ajoberstar.grgit.auth.password'
 	static final String SSH_PRIVATE_KEY_OPTION = 'org.ajoberstar.grgit.auth.ssh.private'
+	static final String SSH_SESSION_CONFIG_OPTION_PREFIX = 'org.ajoberstar.grgit.auth.session.config.'
 
 	/**
 	 * Set of all authentication options that are allowed in this
@@ -125,6 +134,16 @@ class AuthConfig {
 	 */
 	String getSshPrivateKeyPath() {
 		return System.properties[SSH_PRIVATE_KEY_OPTION]
+	}
+
+	/**
+	 * Gets session config override for SSH session that is used underneath by JGit
+	 * @return map with configuration or empty if nothing was specified in system property
+	 */
+	Map<String, String> getSessionConfig() {
+		return System.properties
+                .findAll { it -> it.key.startsWith(SSH_SESSION_CONFIG_OPTION_PREFIX) }
+                .collectEntries { it -> [ it.key.substring(SSH_SESSION_CONFIG_OPTION_PREFIX.length()), it.value] }
 	}
 
 	/**

--- a/src/main/groovy/org/ajoberstar/grgit/auth/JschAgentProxySessionFactory.groovy
+++ b/src/main/groovy/org/ajoberstar/grgit/auth/JschAgentProxySessionFactory.groovy
@@ -48,10 +48,10 @@ class JschAgentProxySessionFactory extends JschConfigSessionFactory {
 	}
 
 	/**
-	 * No actions performed by this.
+	 * Customize session
 	 */
 	protected void configure(Host hc, Session session) {
-		// no action
+	    config.sessionConfig.each { key, value -> session.setConfig(key, value) }
 	}
 
 	/**

--- a/src/test/groovy/org/ajoberstar/grgit/auth/AuthConfigSpec.groovy
+++ b/src/test/groovy/org/ajoberstar/grgit/auth/AuthConfigSpec.groovy
@@ -69,4 +69,16 @@ class AuthConfigSpec extends Specification {
 		expect:
 		AuthConfig.fromMap([:]).getHardcodedCreds() == null
 	}
+
+	def 'getSessionConfig returns empty map if nothing specified'() {
+		expect:
+		AuthConfig.fromMap(Collections.emptyMap()).sessionConfig.isEmpty()
+	}
+
+	def 'getSessionConfig returns session config based on system property'() {
+		given:
+		System.setProperty(AuthConfig.SSH_SESSION_CONFIG_OPTION_PREFIX + 'StrictHostKeyChecking', 'no')
+		expect:
+		AuthConfig.fromMap(Collections.emptyMap()).sessionConfig == [ StrictHostKeyChecking: 'no' ]
+	}
 }


### PR DESCRIPTION
Now someone could run it in this way:
```
./gradlew release -Dorg.ajoberstar.grgit.auth.ssh.private=~/.ssh/github_id_rsa \
-Dorg.ajoberstar.grgit.auth.session.config.StrictHostKeyChecking=no
```