### PR TITLE
Add the MergeResult to the exception thrown when a merge fails

### DIFF
--- a/src/main/groovy/org/ajoberstar/grgit/exception/GrgitMergeException.groovy
+++ b/src/main/groovy/org/ajoberstar/grgit/exception/GrgitMergeException.groovy
@@ -25,7 +25,7 @@ import org.eclipse.jgit.api.MergeResult
  */
 @InheritConstructors
 @CompileStatic
-class GrgitMergeException extends RuntimeException {
+class GrgitMergeException extends GrgitException {
 	MergeResult mergeResult
 
 	GrgitMergeException(String message, MergeResult mergeResult) {

--- a/src/main/groovy/org/ajoberstar/grgit/exception/GrgitMergeException.groovy
+++ b/src/main/groovy/org/ajoberstar/grgit/exception/GrgitMergeException.groovy
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2012-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ajoberstar.grgit.exception
+
+import groovy.transform.CompileStatic
+import groovy.transform.InheritConstructors
+
+import org.eclipse.jgit.api.MergeResult
+
+/**
+ * Generic exception for merge failures in use of Grgit.
+ */
+@InheritConstructors
+@CompileStatic
+class GrgitMergeException extends RuntimeException {
+	MergeResult mergeResult
+
+	GrgitMergeException(String message, MergeResult mergeResult) {
+		super(message)
+		this.mergeResult = mergeResult
+	}
+}

--- a/src/main/groovy/org/ajoberstar/grgit/operation/MergeOp.groovy
+++ b/src/main/groovy/org/ajoberstar/grgit/operation/MergeOp.groovy
@@ -19,6 +19,7 @@ import java.util.concurrent.Callable
 
 import org.ajoberstar.grgit.Repository
 import org.ajoberstar.grgit.exception.GrgitException
+import org.ajoberstar.grgit.exception.GrgitMergeException
 import org.ajoberstar.grgit.service.ResolveService
 import org.ajoberstar.grgit.util.JGitUtil
 
@@ -107,7 +108,7 @@ class MergeOp implements Callable<Void> {
 		try {
 			MergeResult result = cmd.call()
 			if (!result.mergeStatus.successful) {
-				throw new GrgitException("Could not merge: ${result}")
+				throw new GrgitMergeException("Could not merge: ${result}", result)
 			}
 			return null
 		} catch (GitAPIException e) {

--- a/src/test/groovy/org/ajoberstar/grgit/operation/MergeOpSpec.groovy
+++ b/src/test/groovy/org/ajoberstar/grgit/operation/MergeOpSpec.groovy
@@ -19,7 +19,7 @@ import static org.ajoberstar.grgit.operation.MergeOp.Mode.*
 
 import org.ajoberstar.grgit.Grgit
 import org.ajoberstar.grgit.Status
-import org.ajoberstar.grgit.exception.GrgitException
+import org.ajoberstar.grgit.exception.GrgitMergeException
 import org.ajoberstar.grgit.fixtures.MultiGitOpSpec
 
 import spock.lang.Unroll
@@ -151,7 +151,7 @@ class MergeOpSpec extends MultiGitOpSpec {
 		then:
 		localGrgit.head() == oldHead
 		localGrgit.status().clean
-		thrown(GrgitException)
+		thrown(GrgitMergeException)
 		where:
 		head              | mode
 		'origin/clean'    | ONLY_FF


### PR DESCRIPTION
Resolves #110.

To accomplish this I changed the exception from GrgitException to a new GrgitMergeException which stores the MergeResult for use by the client. A client can then look at GrgitMergeException#mergeResult.conflicts to determine what the conflicts were and do some custom processing on the conflicted files. (http://download.eclipse.org/jgit/docs/jgit-2.3.1.201302201838-r/apidocs/org/eclipse/jgit/api/MergeResult.html)

I updated the broken tests to refer to the new Exception type, but it should probably also verify that the MergeResult is on the exception. I'm not familiar enough with Spock to know how to do that at the moment.