### PR TITLE
Support Windows-style paths in add/remove patterns

### DIFF
--- a/src/main/groovy/org/ajoberstar/grgit/operation/AddOp.groovy
+++ b/src/main/groovy/org/ajoberstar/grgit/operation/AddOp.groovy
@@ -66,7 +66,7 @@ class AddOp implements Callable<Void> {
 
 	Void call() {
 		AddCommand cmd = repo.jgit.add()
-		patterns.each { cmd.addFilepattern(it) }
+		patterns.each { cmd.addFilepattern(it.replaceAll('\\\\', '/')) }
 		cmd.update = update
 		try {
 			cmd.call()

--- a/src/main/groovy/org/ajoberstar/grgit/operation/RmOp.groovy
+++ b/src/main/groovy/org/ajoberstar/grgit/operation/RmOp.groovy
@@ -65,7 +65,7 @@ class RmOp implements Callable<Void> {
 
 	Void call() {
 		RmCommand cmd = repo.jgit.rm()
-		patterns.each { cmd.addFilepattern(it) }
+		patterns.each { cmd.addFilepattern(it.replaceAll('\\\\', '/')) }
 		cmd.cached = cached
 		try {
 			cmd.call()

--- a/src/test/groovy/org/ajoberstar/grgit/operation/AddOpSpec.groovy
+++ b/src/test/groovy/org/ajoberstar/grgit/operation/AddOpSpec.groovy
@@ -33,6 +33,19 @@ class AddOpSpec extends SimpleGitOpSpec {
 		)
 	}
 
+	def 'adding file using Windows-style path only adds that file'() {
+		given:
+		repoFile('test/1.txt') << '1'
+		repoFile('test/2.txt') << '2'
+		when:
+		grgit.add(patterns: ['test\\1.txt'])
+		then:
+		grgit.status() == new Status(
+				staged: [added: ['test/1.txt']],
+				unstaged: [added: ['test/2.txt']]
+		)
+	}
+
 	def 'adding specific directory adds all files within it'() {
 		given:
 		repoFile('1.txt') << '1'

--- a/src/test/groovy/org/ajoberstar/grgit/operation/RmOpSpec.groovy
+++ b/src/test/groovy/org/ajoberstar/grgit/operation/RmOpSpec.groovy
@@ -39,6 +39,16 @@ class RmOpSpec extends SimpleGitOpSpec {
 		paths.every { !repoFile(it).exists() }
 	}
 
+	def 'removing specific file using Windows-style path only removes that file'() {
+		given:
+		def paths = ['test/3.bat'] as Set
+		when:
+		grgit.remove(patterns:['test\\3.bat'])
+		then:
+		grgit.status() == new Status(staged: [removed: paths])
+		paths.every { !repoFile(it).exists() }
+	}
+
 	def 'removing specific directory removes all files within it'() {
 		given:
 		def paths = ['test/3.bat', 'test/4.txt', 'test/other/5.txt'] as Set


### PR DESCRIPTION
This allows using paths with backslashes in patterns. For example:

```
grgit.add(patterns: ['test\\1.txt'])
grgit.rm(patterns: ['test\\2.txt'])
```
