### PR TITLE
Properly close resources in CloneOp

### DIFF
--- a/src/main/groovy/org/ajoberstar/grgit/operation/CloneOp.groovy
+++ b/src/main/groovy/org/ajoberstar/grgit/operation/CloneOp.groovy
@@ -103,7 +103,7 @@ class CloneOp implements Callable<Grgit> {
         if (refToCheckout) { cmd.branch = refToCheckout }
 
         try {
-            cmd.call()
+            cmd.call().close()
             return Grgit.open(dir: dir, creds: credentials)
         } catch (GitAPIException e) {
             throw new GrgitException('Problem cloning repository.', e)

--- a/src/test/groovy/org/ajoberstar/grgit/operation/CloneOpSpec.groovy
+++ b/src/test/groovy/org/ajoberstar/grgit/operation/CloneOpSpec.groovy
@@ -131,4 +131,13 @@ class CloneOpSpec extends MultiGitOpSpec {
         GitTestUtil.tags(grgit).collect(lastName) == ['tag1']
         GitTestUtil.remotes(grgit) == ['origin']
     }
+
+    def 'cloned repo can be deleted'() {
+        given:
+        def grgit = Grgit.clone(dir: repoDir, uri: remoteUri, refToCheckout: 'refs/heads/branch2')
+        when:
+        grgit.close()
+        then:
+        assert repoDir.deleteDir()
+    }
 }


### PR DESCRIPTION
The CloneCommand in JGit returns a reosurce that must be
closed in order to release a lock on the files in the repo.
This prevents someone from deleting a repo, even though they
close the Grgit instance.

Closing the resource has fixed #132.