### PR TITLE
Add passphrase support for hardcoded authentication

### DIFF
--- a/src/main/groovy/org/ajoberstar/grgit/auth/AuthConfig.groovy
+++ b/src/main/groovy/org/ajoberstar/grgit/auth/AuthConfig.groovy
@@ -68,7 +68,7 @@ import org.ajoberstar.grgit.exception.GrgitException
  *
  * <ul>
  *	 <li>{@code org.ajoberstar.grgit.auth.ssh.private=<path.to.private.key>}</li>
- *	 <li>{@code org.ajoberstar.grgit.auth.ssh.passphrase=<passphrase>}</li>
+ *   <li>{@code org.ajoberstar.grgit.auth.ssh.passphrase=<passphrase>}</li>
  * </ul>
  * <p>
  *   In order to customize the JSch session config use a property of the
@@ -174,14 +174,14 @@ class AuthConfig {
   String getSshPrivateKeyPath() {
     return props[SSH_PRIVATE_KEY_OPTION]
   }
-  
+ 
   /**
    * Gets the passphrase for your SSH private key to use during authentication reflecting
    * the value set in the system properties.
    * @return the passphrase of the SSH key, if set, otherwise {@code null}
    */
   String getSshPassphrase() {
-	return props[SSH_PASSPHRASE_OPTION]
+    return props[SSH_PASSPHRASE_OPTION]
   }
 
   /**

--- a/src/main/groovy/org/ajoberstar/grgit/auth/AuthConfig.groovy
+++ b/src/main/groovy/org/ajoberstar/grgit/auth/AuthConfig.groovy
@@ -174,7 +174,7 @@ class AuthConfig {
   String getSshPrivateKeyPath() {
     return props[SSH_PRIVATE_KEY_OPTION]
   }
- 
+
   /**
    * Gets the passphrase for your SSH private key to use during authentication reflecting
    * the value set in the system properties.

--- a/src/main/groovy/org/ajoberstar/grgit/auth/AuthConfig.groovy
+++ b/src/main/groovy/org/ajoberstar/grgit/auth/AuthConfig.groovy
@@ -60,12 +60,15 @@ import org.ajoberstar.grgit.exception.GrgitException
  * </ul>
  *
  * <p>
+ *   To customize SSH credentials use the following properties.
  *   In order to add a non-standard SSH key to use as your credentials,
- *   use the following property.
+ *   use the first following property.
+ *   In case your private key is protected by a passphrase, use the second property.
  * </p>
  *
  * <ul>
  *	 <li>{@code org.ajoberstar.grgit.auth.ssh.private=<path.to.private.key>}</li>
+ *	 <li>{@code org.ajoberstar.grgit.auth.ssh.passphrase=<passphrase>}</li>
  * </ul>
  * <p>
  *   In order to customize the JSch session config use a property of the
@@ -98,6 +101,7 @@ class AuthConfig {
   static final String USERNAME_OPTION = 'org.ajoberstar.grgit.auth.username'
   static final String PASSWORD_OPTION = 'org.ajoberstar.grgit.auth.password'
   static final String SSH_PRIVATE_KEY_OPTION = 'org.ajoberstar.grgit.auth.ssh.private'
+  static final String SSH_PASSPHRASE_OPTION = 'org.ajoberstar.grgit.auth.ssh.passphrase'
   static final String SSH_SESSION_CONFIG_OPTION_PREFIX = 'org.ajoberstar.grgit.auth.session.config.'
 
   static final String USERNAME_ENV_VAR = 'GRGIT_USER'
@@ -169,6 +173,15 @@ class AuthConfig {
    */
   String getSshPrivateKeyPath() {
     return props[SSH_PRIVATE_KEY_OPTION]
+  }
+  
+  /**
+   * Gets the passphrase for your SSH private key to use during authentication reflecting
+   * the value set in the system properties.
+   * @return the passphrase of the SSH key, if set, otherwise {@code null}
+   */
+  String getSshPassphrase() {
+	return props[SSH_PASSPHRASE_OPTION]
   }
 
   /**

--- a/src/main/groovy/org/ajoberstar/grgit/auth/JschAgentProxySessionFactory.groovy
+++ b/src/main/groovy/org/ajoberstar/grgit/auth/JschAgentProxySessionFactory.groovy
@@ -70,8 +70,8 @@ class JschAgentProxySessionFactory extends JschConfigSessionFactory {
     }
 
     if (config.sshPrivateKeyPath) {
-	  if (config.getSshPassphrase())
-	    jsch.addIdentity(config.sshPrivateKeyPath, config.getSshPassphrase())
+      if (config.getSshPassphrase())
+        jsch.addIdentity(config.sshPrivateKeyPath, config.getSshPassphrase())
       jsch.addIdentity(config.sshPrivateKeyPath)
     }
 

--- a/src/main/groovy/org/ajoberstar/grgit/auth/JschAgentProxySessionFactory.groovy
+++ b/src/main/groovy/org/ajoberstar/grgit/auth/JschAgentProxySessionFactory.groovy
@@ -70,6 +70,8 @@ class JschAgentProxySessionFactory extends JschConfigSessionFactory {
     }
 
     if (config.sshPrivateKeyPath) {
+	  if (config.getSshPassphrase())
+		  jsch.addIdentity(config.sshPrivateKeyPath, config.getSshPassphrase())
       jsch.addIdentity(config.sshPrivateKeyPath)
     }
 

--- a/src/main/groovy/org/ajoberstar/grgit/auth/JschAgentProxySessionFactory.groovy
+++ b/src/main/groovy/org/ajoberstar/grgit/auth/JschAgentProxySessionFactory.groovy
@@ -71,7 +71,7 @@ class JschAgentProxySessionFactory extends JschConfigSessionFactory {
 
     if (config.sshPrivateKeyPath) {
 	  if (config.getSshPassphrase())
-		  jsch.addIdentity(config.sshPrivateKeyPath, config.getSshPassphrase())
+	    jsch.addIdentity(config.sshPrivateKeyPath, config.getSshPassphrase())
       jsch.addIdentity(config.sshPrivateKeyPath)
     }
 


### PR DESCRIPTION
When your repository is asking you a passphrase is could be painfull to have to give it for all your repo. You could enter it once when typing from your command line or when we create the grgit instance.

use -Dorg.ajoberstar.grgit.auth.passphrase=passphrase && -Dorg.ajoberstar.grgit.auth.force=hardcoded 
This will allow you tu use default ssl authentication + hardcoded passphrase usage

Please say if I have done a mistake or if my request should be improved in any way.