### PR TITLE
Fix username-only creds

### DIFF
--- a/src/main/groovy/org/ajoberstar/grgit/Credentials.groovy
+++ b/src/main/groovy/org/ajoberstar/grgit/Credentials.groovy
@@ -15,14 +15,26 @@
  */
 package org.ajoberstar.grgit
 
-import groovy.transform.Immutable
+import groovy.transform.Canonical
 
 /**
  * Credentials to use for remote operations.
  * @since 0.2.0
  */
-@Immutable
+@Canonical
 class Credentials {
-  String username
-  String password
+  final String username
+  final String password
+
+  String getUsername() {
+    return username ?: ''
+  }
+
+  String getPassword() {
+    return password ?: ''
+  }
+
+  boolean isPopulated() {
+    return username != null
+  }
 }

--- a/src/main/groovy/org/ajoberstar/grgit/auth/AuthConfig.groovy
+++ b/src/main/groovy/org/ajoberstar/grgit/auth/AuthConfig.groovy
@@ -156,11 +156,7 @@ class AuthConfig {
     if (allows(Option.HARDCODED)) {
       String username = props[USERNAME_OPTION] ?: env[USERNAME_ENV_VAR]
       String password = props[PASSWORD_OPTION] ?: env[PASSWORD_ENV_VAR]
-      if (username) {
-        return new Credentials(username, password)
-      } else {
-        return null
-      }
+      return new Credentials(username, password)
     } else {
       return null
     }

--- a/src/main/groovy/org/ajoberstar/grgit/auth/TransportOpUtil.groovy
+++ b/src/main/groovy/org/ajoberstar/grgit/auth/TransportOpUtil.groovy
@@ -52,10 +52,10 @@ final class TransportOpUtil {
 
   private static CredentialsProvider determineCredentialsProvider(AuthConfig config, Credentials creds) {
     Credentials systemCreds = config.hardcodedCreds
-    if (config.allows(AuthConfig.Option.HARDCODED) && creds?.username) {
+    if (config.allows(AuthConfig.Option.HARDCODED) && creds?.populated) {
       logger.info('using hardcoded credentials provided programmatically')
       return new UsernamePasswordCredentialsProvider(creds.username, creds.password)
-    } else if (config.allows(AuthConfig.Option.HARDCODED) && systemCreds) {
+    } else if (config.allows(AuthConfig.Option.HARDCODED) && systemCreds?.populated) {
       logger.info('using hardcoded credentials from system properties')
       return new UsernamePasswordCredentialsProvider(systemCreds.username, systemCreds.password)
     } else if (config.allows(AuthConfig.Option.INTERACTIVE) && !GraphicsEnvironment.isHeadless()) {

--- a/src/test/groovy/org/ajoberstar/grgit/auth/AuthConfigSpec.groovy
+++ b/src/test/groovy/org/ajoberstar/grgit/auth/AuthConfigSpec.groovy
@@ -67,9 +67,9 @@ class AuthConfigSpec extends Specification {
     AuthConfig.fromMap(props).getHardcodedCreds() == new Credentials('myuser', null)
   }
 
-  def 'getHardcodedCreds returns null if username is not set'() {
+  def 'getHardcodedCreds are not populated if username is not set'() {
     expect:
-    AuthConfig.fromMap([:]).getHardcodedCreds() == null
+    !AuthConfig.fromMap([:]).getHardcodedCreds().isPopulated()
   }
 
   def 'getSessionConfig returns empty map if nothing specified'() {

--- a/src/test/groovy/org/ajoberstar/grgit/auth/WindowsAuthenticationSpec.groovy
+++ b/src/test/groovy/org/ajoberstar/grgit/auth/WindowsAuthenticationSpec.groovy
@@ -46,7 +46,7 @@ class WindowsAuthenticationSpec extends Specification {
     def username = System.properties['org.ajoberstar.grgit.test.username']
     def password = System.properties['org.ajoberstar.grgit.test.password']
     hardcodedCreds = new Credentials(username, password)
-    partialCreds = new Credentials(username, null)
+    partialCreds = new Credentials(password, null)
     assert hardcodedCreds.username && hardcodedCreds.password
   }
 
@@ -63,7 +63,7 @@ class WindowsAuthenticationSpec extends Specification {
     assert System.properties[AuthConfig.USERNAME_OPTION] == null, 'Username should not already be set.'
     assert System.properties[AuthConfig.PASSWORD_OPTION] == null, 'Password should not already be set.'
     System.properties[AuthConfig.FORCE_OPTION] = method
-    ready(ssh, creds)
+    ready(ssh)
     if (!creds) {
       System.properties[AuthConfig.USERNAME_OPTION] = hardcodedCreds.username
       System.properties[AuthConfig.PASSWORD_OPTION] = hardcodedCreds.password
@@ -74,20 +74,20 @@ class WindowsAuthenticationSpec extends Specification {
     then:
     grgit.branch.status(branch: 'master').aheadCount == 0
     where:
-    method		| ssh   | creds
+    method		    | ssh   | creds
     'hardcoded'   | false | hardcodedCreds
     'hardcoded'   | false | partialCreds
     'hardcoded'   | false | null
     'interactive' | false | null
     'interactive' | true  | null
-    'sshagent'	| true  | null
-    'pageant'	 | true  | null
+    'sshagent'	  | true  | null
+    'pageant'	    | true  | null
   }
 
-  private void ready(boolean ssh, Credentials credentials = null) {
+  private void ready(boolean ssh) {
     File repoDir = tempDir.newFolder('repo')
     String uri = ssh ? SSH_URI : HTTPS_URI
-    grgit = Grgit.clone(uri: uri, dir: repoDir, credentials: credentials)
+    grgit = Grgit.clone(uri: uri, dir: repoDir)
     grgit.repository.jgit.repo.config.with {
       setString('user', null, 'name', person.name)
       setString('user', null, 'email', person.email)


### PR DESCRIPTION
Username-only creds are useful for things like GitHub access tokens.
Prior to this commit, specifying only a username resulted in a null
password, which caused an ambiguous method call to the
UserNamePasswordCredentialsProvider constructor.

Now Credentials has been beefed up to fallback to empty strings for
values that aren't provided. There's also an explicit method for how to
check the validity of a Credentials object rather than needing to
specify it directly in each case.

Fixes #153