### PR TITLE
Added --long option to Describe operation.

### DIFF
--- a/src/main/groovy/org/ajoberstar/grgit/operation/DescribeOp.groovy
+++ b/src/main/groovy/org/ajoberstar/grgit/operation/DescribeOp.groovy
@@ -41,6 +41,12 @@ import org.eclipse.jgit.api.errors.GitAPIException
  * def description = grgit.describe(commit: 'other-branch')
  * </pre>
  *
+ * <p>Always output the long format (the tag, the number of commits and the abbreviated commit name) even when it matches a tag.</p>
+ *
+ * <pre>
+ * def description = grgit.describe(longDescr: true)
+ * </pre>
+ *
  * See <a href="http://git-scm.com/docs/git-describe">git-describe Manual Page</a>.
  *
  * @see <a href="http://git-scm.com/docs/git-describe">git-describe Manual Page</a>
@@ -58,6 +64,10 @@ class DescribeOp implements Callable<String> {
    */
   Object commit
 
+  /**
+   * Whether to always use long output format or not.
+   */
+  boolean longDescr
 
   String call(){
     DescribeCommand cmd = repo.jgit.describe()
@@ -65,6 +75,7 @@ class DescribeOp implements Callable<String> {
       if (commit) {
         cmd.setTarget(new ResolveService(repo).toRevisionString(commit))
       }
+    cmd.setLong(longDescr)
       return cmd.call()
     } catch (GitAPIException e) {
       throw new GrgitException('Problem retrieving description.', e)

--- a/src/test/groovy/org/ajoberstar/grgit/operation/DescribeOpSpec.groovy
+++ b/src/test/groovy/org/ajoberstar/grgit/operation/DescribeOpSpec.groovy
@@ -45,4 +45,9 @@ class DescribeOpSpec extends SimpleGitOpSpec {
     then:
     grgit.describe(commit: 'HEAD^') == "initial"
   }
+
+  def 'with long description'() {
+    expect:
+    grgit.describe(longDescr: true).startsWith("initial-0-")
+  }
 }


### PR DESCRIPTION
I currently patching the **grgit** in my `buildSrc` using the `metaClass`. 
In the end, it would be nice to transfer everything you consider to be fit and of common interests into grgit.
I think this one is still uncritical, so I provided it as a separated PR.

As you saw in my proposal for gradle-git, I still have some blind spots when it comes to GIT. Sorry that I was wasting your time.