### PR TITLE
Use Java 8's java.time in Commit and Tag

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+semver.scope=major

--- a/gradle/HEADER
+++ b/gradle/HEADER
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/org/ajoberstar/grgit/Branch.groovy
+++ b/src/main/groovy/org/ajoberstar/grgit/Branch.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/org/ajoberstar/grgit/BranchStatus.groovy
+++ b/src/main/groovy/org/ajoberstar/grgit/BranchStatus.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/org/ajoberstar/grgit/Commit.groovy
+++ b/src/main/groovy/org/ajoberstar/grgit/Commit.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/org/ajoberstar/grgit/Commit.groovy
+++ b/src/main/groovy/org/ajoberstar/grgit/Commit.groovy
@@ -16,12 +16,13 @@
 package org.ajoberstar.grgit
 
 import groovy.transform.Immutable
+import java.time.ZonedDateTime
 
 /**
  * A commit.
  * @since 0.1.0
  */
- @Immutable
+ @Immutable(knownImmutableClasses=[ZonedDateTime])
 class Commit {
   /**
    * The full hash of the commit.
@@ -44,9 +45,9 @@ class Commit {
   Person committer
 
   /**
-   * The time the commit was created in seconds since "the epoch".
+   * The time the commit was created with the time zone of the committer, if available.
    */
-  int time
+  ZonedDateTime dateTime
 
   /**
    * The full commit message.
@@ -59,12 +60,23 @@ class Commit {
   String shortMessage
 
   /**
+   * The time the commit was created in seconds since "the epoch".
+   * @return the time
+   * @deprecated use Commit#dateTime
+   */
+  @Deprecated
+  long getTime() {
+    return dateTime.toEpochSecond()
+  }
+
+  /**
    * The time the commit was created.
    * @return the date
+   * @deprecated use Commit#dateTime
    */
+  @Deprecated
   Date getDate() {
-    long seconds = Integer.valueOf(time).longValue()
-    return new Date(seconds * 1000)
+    return dateTime.toDate()
   }
 
   /**

--- a/src/main/groovy/org/ajoberstar/grgit/CommitDiff.groovy
+++ b/src/main/groovy/org/ajoberstar/grgit/CommitDiff.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/org/ajoberstar/grgit/Credentials.groovy
+++ b/src/main/groovy/org/ajoberstar/grgit/Credentials.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/org/ajoberstar/grgit/Grgit.groovy
+++ b/src/main/groovy/org/ajoberstar/grgit/Grgit.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/org/ajoberstar/grgit/Grgit.groovy
+++ b/src/main/groovy/org/ajoberstar/grgit/Grgit.groovy
@@ -76,6 +76,7 @@ import org.ajoberstar.grgit.util.JGitUtil
  *   <li>{@link org.ajoberstar.grgit.operation.DescribeOp describe}</li>
  *   <li>{@link org.ajoberstar.grgit.operation.FetchOp fetch}</li>
  *   <li>{@link org.ajoberstar.grgit.operation.LogOp log}</li>
+ *   <li>{@link org.ajoberstar.grgit.operation.LsRemoteOp lsremote}</li>
  *   <li>{@link org.ajoberstar.grgit.operation.MergeOp merge}</li>
  *   <li>{@link org.ajoberstar.grgit.operation.PullOp pull}</li>
  *   <li>{@link org.ajoberstar.grgit.operation.PushOp push}</li>
@@ -109,7 +110,7 @@ import org.ajoberstar.grgit.util.JGitUtil
  *
  * @since 0.1.0
  */
-@WithOperations(staticOperations=[InitOp, CloneOp, OpenOp], instanceOperations=[CleanOp, StatusOp, AddOp, RmOp, ResetOp, ApplyOp, PullOp, PushOp, FetchOp, CheckoutOp, LogOp, CommitOp, RevertOp, MergeOp, DescribeOp, ShowOp])
+@WithOperations(staticOperations=[InitOp, CloneOp, OpenOp], instanceOperations=[CleanOp, StatusOp, AddOp, RmOp, ResetOp, ApplyOp, PullOp, PushOp, FetchOp, LsRemoteOp, CheckoutOp, LogOp, CommitOp, RevertOp, MergeOp, DescribeOp, ShowOp])
 class Grgit implements AutoCloseable {
   /**
    * The repository opened by this object.

--- a/src/main/groovy/org/ajoberstar/grgit/Person.groovy
+++ b/src/main/groovy/org/ajoberstar/grgit/Person.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/org/ajoberstar/grgit/Ref.groovy
+++ b/src/main/groovy/org/ajoberstar/grgit/Ref.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/org/ajoberstar/grgit/Ref.groovy
+++ b/src/main/groovy/org/ajoberstar/grgit/Ref.groovy
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2012-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ajoberstar.grgit
+
+import groovy.transform.Immutable
+
+import org.eclipse.jgit.lib.Repository
+
+/**
+ * A ref.
+ * @since 2.0.0
+ */
+@Immutable
+class Ref {
+  /**
+   * The fully qualified name of this ref.
+   */
+  String fullName
+
+  /**
+   * The simple name of the ref.
+   * @return the simple name
+   */
+  String getName() {
+    return Repository.shortenRefName(fullName)
+  }
+}

--- a/src/main/groovy/org/ajoberstar/grgit/Remote.groovy
+++ b/src/main/groovy/org/ajoberstar/grgit/Remote.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/org/ajoberstar/grgit/Repository.groovy
+++ b/src/main/groovy/org/ajoberstar/grgit/Repository.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/org/ajoberstar/grgit/Status.groovy
+++ b/src/main/groovy/org/ajoberstar/grgit/Status.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/org/ajoberstar/grgit/Tag.groovy
+++ b/src/main/groovy/org/ajoberstar/grgit/Tag.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/org/ajoberstar/grgit/Tag.groovy
+++ b/src/main/groovy/org/ajoberstar/grgit/Tag.groovy
@@ -17,13 +17,15 @@ package org.ajoberstar.grgit
 
 import groovy.transform.Immutable
 
+import java.time.ZonedDateTime
+
 import org.eclipse.jgit.lib.Repository
 
 /**
  * A tag.
  * @since 0.2.0
  */
-@Immutable
+@Immutable(knownImmutableClasses=[ZonedDateTime])
 class Tag {
   /**
    * The commit this tag points to.
@@ -49,6 +51,11 @@ class Tag {
    * The shortened tag message.
    */
   String shortMessage
+
+  /**
+   * The time the commit was created with the time zone of the committer, if available.
+   */
+  ZonedDateTime dateTime
 
   /**
    * The simple name of this tag.

--- a/src/main/groovy/org/ajoberstar/grgit/auth/AuthConfig.groovy
+++ b/src/main/groovy/org/ajoberstar/grgit/auth/AuthConfig.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/org/ajoberstar/grgit/auth/JschAgentProxyConfigCallback.groovy
+++ b/src/main/groovy/org/ajoberstar/grgit/auth/JschAgentProxyConfigCallback.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/org/ajoberstar/grgit/auth/JschAgentProxySessionFactory.groovy
+++ b/src/main/groovy/org/ajoberstar/grgit/auth/JschAgentProxySessionFactory.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/org/ajoberstar/grgit/auth/TransportOpUtil.groovy
+++ b/src/main/groovy/org/ajoberstar/grgit/auth/TransportOpUtil.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/org/ajoberstar/grgit/auth/package-info.groovy
+++ b/src/main/groovy/org/ajoberstar/grgit/auth/package-info.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/org/ajoberstar/grgit/exception/GrgitException.groovy
+++ b/src/main/groovy/org/ajoberstar/grgit/exception/GrgitException.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/org/ajoberstar/grgit/exception/package-info.groovy
+++ b/src/main/groovy/org/ajoberstar/grgit/exception/package-info.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/org/ajoberstar/grgit/internal/OpSyntax.groovy
+++ b/src/main/groovy/org/ajoberstar/grgit/internal/OpSyntax.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/org/ajoberstar/grgit/internal/Operation.java
+++ b/src/main/groovy/org/ajoberstar/grgit/internal/Operation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/org/ajoberstar/grgit/internal/WithOperations.java
+++ b/src/main/groovy/org/ajoberstar/grgit/internal/WithOperations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/org/ajoberstar/grgit/internal/WithOperationsASTTransformation.java
+++ b/src/main/groovy/org/ajoberstar/grgit/internal/WithOperationsASTTransformation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/org/ajoberstar/grgit/operation/AddOp.groovy
+++ b/src/main/groovy/org/ajoberstar/grgit/operation/AddOp.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/org/ajoberstar/grgit/operation/ApplyOp.groovy
+++ b/src/main/groovy/org/ajoberstar/grgit/operation/ApplyOp.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/org/ajoberstar/grgit/operation/BranchAddOp.groovy
+++ b/src/main/groovy/org/ajoberstar/grgit/operation/BranchAddOp.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/org/ajoberstar/grgit/operation/BranchChangeOp.groovy
+++ b/src/main/groovy/org/ajoberstar/grgit/operation/BranchChangeOp.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/org/ajoberstar/grgit/operation/BranchListOp.groovy
+++ b/src/main/groovy/org/ajoberstar/grgit/operation/BranchListOp.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/org/ajoberstar/grgit/operation/BranchRemoveOp.groovy
+++ b/src/main/groovy/org/ajoberstar/grgit/operation/BranchRemoveOp.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/org/ajoberstar/grgit/operation/BranchStatusOp.groovy
+++ b/src/main/groovy/org/ajoberstar/grgit/operation/BranchStatusOp.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/org/ajoberstar/grgit/operation/CheckoutOp.groovy
+++ b/src/main/groovy/org/ajoberstar/grgit/operation/CheckoutOp.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/org/ajoberstar/grgit/operation/CleanOp.groovy
+++ b/src/main/groovy/org/ajoberstar/grgit/operation/CleanOp.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/org/ajoberstar/grgit/operation/CloneOp.groovy
+++ b/src/main/groovy/org/ajoberstar/grgit/operation/CloneOp.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/org/ajoberstar/grgit/operation/CommitOp.groovy
+++ b/src/main/groovy/org/ajoberstar/grgit/operation/CommitOp.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/org/ajoberstar/grgit/operation/DescribeOp.groovy
+++ b/src/main/groovy/org/ajoberstar/grgit/operation/DescribeOp.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/org/ajoberstar/grgit/operation/FetchOp.groovy
+++ b/src/main/groovy/org/ajoberstar/grgit/operation/FetchOp.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/org/ajoberstar/grgit/operation/InitOp.groovy
+++ b/src/main/groovy/org/ajoberstar/grgit/operation/InitOp.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/org/ajoberstar/grgit/operation/LogOp.groovy
+++ b/src/main/groovy/org/ajoberstar/grgit/operation/LogOp.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/org/ajoberstar/grgit/operation/LsRemoteOp.groovy
+++ b/src/main/groovy/org/ajoberstar/grgit/operation/LsRemoteOp.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/org/ajoberstar/grgit/operation/LsRemoteOp.groovy
+++ b/src/main/groovy/org/ajoberstar/grgit/operation/LsRemoteOp.groovy
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2012-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ajoberstar.grgit.operation
+
+import java.util.concurrent.Callable
+
+import org.ajoberstar.grgit.Ref
+import org.ajoberstar.grgit.Repository
+import org.ajoberstar.grgit.exception.GrgitException
+import org.ajoberstar.grgit.internal.Operation
+import org.eclipse.jgit.api.LsRemoteCommand
+import org.eclipse.jgit.api.errors.GitAPIException
+import org.eclipse.jgit.lib.ObjectId
+
+/**
+ * Gets a log of commits in the repository. Returns a list of {@link Commit}s.
+ * Since a Git history is not necessarilly a line, these commits may not be in
+ * a strict order.
+ *
+ * <p>Get a full log of commits from the current HEAD and back.</p>
+ *
+ * <pre>
+ * def history = grgit.log()
+ * </pre>
+ *
+ * <p>Get log of commits between two points.</p>
+ *
+ * <pre>
+ * def history = grgit.log {
+ *  range 'v1.0', 'v2.0'
+ * }
+ * </pre>
+ *
+ * <p>Get a list of the most recent 5 commits.</p>
+ *
+ * <pre>
+ * def history = grgit.log(maxCommits: 5)
+ * </pre>
+ *
+ * <p>Get a log of commits skipping the most recent 3.</p>
+ *
+ * <pre>
+ * def history = grgit.log(skipCommits: 3)
+ * </pre>
+ *
+ * See <a href="https://git-scm.com/docs/git-ls-remote">git-ls-remote Manual Page</a>.
+ *
+ * @since 2.0.0
+ * @see <a href="https://git-scm.com/docs/git-ls-remote">git-ls-remote Manual Page</a>
+ */
+@Operation('lsremote')
+class LsRemoteOp implements Callable<Map<Ref, String>> {
+  private final Repository repo
+
+  String remote = 'origin'
+
+  boolean heads = false
+
+  boolean tags = false
+
+  LsRemoteOp(Repository repo) {
+    this.repo = repo
+  }
+
+  Map<Ref, String> call() {
+  LsRemoteCommand cmd = repo.jgit.lsRemote()
+  cmd.remote = remote
+  cmd.heads = heads
+  cmd.tags = tags
+    try {
+      return cmd.call().collectEntries { jgitRef ->
+        Ref ref = new Ref(jgitRef.getName())
+        [(ref): ObjectId.toString(jgitRef.getObjectId())]
+      }.asImmutable()
+    } catch (GitAPIException e) {
+      throw new GrgitException('Problem retrieving ls-remote.', e)
+    }
+  }
+}

--- a/src/main/groovy/org/ajoberstar/grgit/operation/MergeOp.groovy
+++ b/src/main/groovy/org/ajoberstar/grgit/operation/MergeOp.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/org/ajoberstar/grgit/operation/OpenOp.groovy
+++ b/src/main/groovy/org/ajoberstar/grgit/operation/OpenOp.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/org/ajoberstar/grgit/operation/PullOp.groovy
+++ b/src/main/groovy/org/ajoberstar/grgit/operation/PullOp.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/org/ajoberstar/grgit/operation/PushOp.groovy
+++ b/src/main/groovy/org/ajoberstar/grgit/operation/PushOp.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/org/ajoberstar/grgit/operation/RemoteAddOp.groovy
+++ b/src/main/groovy/org/ajoberstar/grgit/operation/RemoteAddOp.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/org/ajoberstar/grgit/operation/RemoteListOp.groovy
+++ b/src/main/groovy/org/ajoberstar/grgit/operation/RemoteListOp.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/org/ajoberstar/grgit/operation/ResetOp.groovy
+++ b/src/main/groovy/org/ajoberstar/grgit/operation/ResetOp.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/org/ajoberstar/grgit/operation/RevertOp.groovy
+++ b/src/main/groovy/org/ajoberstar/grgit/operation/RevertOp.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/org/ajoberstar/grgit/operation/RmOp.groovy
+++ b/src/main/groovy/org/ajoberstar/grgit/operation/RmOp.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/org/ajoberstar/grgit/operation/ShowOp.groovy
+++ b/src/main/groovy/org/ajoberstar/grgit/operation/ShowOp.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/org/ajoberstar/grgit/operation/StatusOp.groovy
+++ b/src/main/groovy/org/ajoberstar/grgit/operation/StatusOp.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/org/ajoberstar/grgit/operation/TagAddOp.groovy
+++ b/src/main/groovy/org/ajoberstar/grgit/operation/TagAddOp.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/org/ajoberstar/grgit/operation/TagListOp.groovy
+++ b/src/main/groovy/org/ajoberstar/grgit/operation/TagListOp.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/org/ajoberstar/grgit/operation/TagRemoveOp.groovy
+++ b/src/main/groovy/org/ajoberstar/grgit/operation/TagRemoveOp.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/org/ajoberstar/grgit/operation/package-info.groovy
+++ b/src/main/groovy/org/ajoberstar/grgit/operation/package-info.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/org/ajoberstar/grgit/package-info.groovy
+++ b/src/main/groovy/org/ajoberstar/grgit/package-info.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/org/ajoberstar/grgit/service/BranchService.groovy
+++ b/src/main/groovy/org/ajoberstar/grgit/service/BranchService.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/org/ajoberstar/grgit/service/RemoteService.groovy
+++ b/src/main/groovy/org/ajoberstar/grgit/service/RemoteService.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/org/ajoberstar/grgit/service/ResolveService.groovy
+++ b/src/main/groovy/org/ajoberstar/grgit/service/ResolveService.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/org/ajoberstar/grgit/service/ResolveService.groovy
+++ b/src/main/groovy/org/ajoberstar/grgit/service/ResolveService.groovy
@@ -18,8 +18,10 @@ package org.ajoberstar.grgit.service
 import org.ajoberstar.grgit.Branch
 import org.ajoberstar.grgit.Commit
 import org.ajoberstar.grgit.Repository
+import org.ajoberstar.grgit.Ref
 import org.ajoberstar.grgit.Tag
 import org.ajoberstar.grgit.util.JGitUtil
+import org.eclipse.jgit.lib.ObjectId
 
 /**
  * Convenience methods to resolve various objects.
@@ -30,6 +32,32 @@ class ResolveService {
 
   ResolveService(Repository repository) {
     this.repository = repository
+  }
+
+  /**
+   * Resolves an object ID from the given object. Can handle any of the following
+   * types:
+   *
+   * <ul>
+   *   <li>{@link org.ajoberstar.grgit.Commit}</li>
+   *   <li>{@link org.ajoberstar.grgit.Tag}</li>
+   *   <li>{@link org.ajoberstar.grgit.Branch}</li>
+   *   <li>{@link org.ajoberstar.grgit.Ref}</li>
+   * </ul>
+   *
+   * @param object the object to resolve
+   * @return the corresponding object id
+   */
+  String toObjectId(Object object) {
+    if (object == null) {
+      return null
+    } else if (object instanceof Commit) {
+      return object.id
+    } else if (object instanceof Branch || object instanceof Tag || object instanceof Ref) {
+      return ObjectId.toString(repository.jgit.repository.getRef(object.fullName).objectId)
+    } else {
+      throwIllegalArgument(object)
+    }
   }
 
   /**

--- a/src/main/groovy/org/ajoberstar/grgit/service/TagService.groovy
+++ b/src/main/groovy/org/ajoberstar/grgit/service/TagService.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/org/ajoberstar/grgit/service/package-info.groovy
+++ b/src/main/groovy/org/ajoberstar/grgit/service/package-info.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/org/ajoberstar/grgit/util/CoercionUtil.groovy
+++ b/src/main/groovy/org/ajoberstar/grgit/util/CoercionUtil.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/org/ajoberstar/grgit/util/JGitUtil.groovy
+++ b/src/main/groovy/org/ajoberstar/grgit/util/JGitUtil.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/groovy/org/ajoberstar/grgit/util/JGitUtil.groovy
+++ b/src/main/groovy/org/ajoberstar/grgit/util/JGitUtil.groovy
@@ -15,6 +15,11 @@
  */
 package org.ajoberstar.grgit.util
 
+import java.time.Instant
+import java.time.ZoneId
+import java.time.ZoneOffset
+import java.time.ZonedDateTime
+
 import org.ajoberstar.grgit.Branch
 import org.ajoberstar.grgit.Commit
 import org.ajoberstar.grgit.Person
@@ -23,7 +28,6 @@ import org.ajoberstar.grgit.Repository
 import org.ajoberstar.grgit.Status
 import org.ajoberstar.grgit.Tag
 import org.ajoberstar.grgit.exception.GrgitException
-
 import org.eclipse.jgit.errors.AmbiguousObjectException
 import org.eclipse.jgit.errors.IncorrectObjectTypeException
 import org.eclipse.jgit.errors.MissingObjectException
@@ -146,7 +150,13 @@ class JGitUtil {
     props.committer = new Person(committer.name, committer.emailAddress)
     PersonIdent author = rev.authorIdent
     props.author = new Person(author.name, author.emailAddress)
-    props.time = rev.commitTime
+
+    Instant instant = Instant.ofEpochSecond(rev.commitTime)
+    ZoneId zone = Optional.ofNullable(rev.committerIdent.timeZone)
+      .map { it.toZoneId() }
+      .orElse(ZoneOffset.UTC)
+    props.dateTime = ZonedDateTime.ofInstant(instant, zone)
+
     props.fullMessage = rev.fullMessage
     props.shortMessage = rev.shortMessage
     props.parentIds = rev.parents.collect { ObjectId.toString(it) }
@@ -184,6 +194,12 @@ class JGitUtil {
       props.tagger = new Person(tagger.name, tagger.emailAddress)
       props.fullMessage = rev.fullMessage
       props.shortMessage = rev.shortMessage
+
+      Instant instant = rev.taggerIdent.when.toInstant()
+      ZoneId zone = Optional.ofNullable(rev.taggerIdent.timeZone)
+        .map { it.toZoneId() }
+        .orElse(ZoneOffset.UTC)
+      props.dateTime = ZonedDateTime.ofInstant(instant, zone)
     } catch (IncorrectObjectTypeException e) {
       props.commit = resolveCommit(repo, ref.objectId)
     }

--- a/src/main/groovy/org/ajoberstar/grgit/util/package-info.groovy
+++ b/src/main/groovy/org/ajoberstar/grgit/util/package-info.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/groovy/org/ajoberstar/grgit/auth/AuthConfigSpec.groovy
+++ b/src/test/groovy/org/ajoberstar/grgit/auth/AuthConfigSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/groovy/org/ajoberstar/grgit/auth/LinuxAuthenticationSpec.groovy
+++ b/src/test/groovy/org/ajoberstar/grgit/auth/LinuxAuthenticationSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/groovy/org/ajoberstar/grgit/auth/MacAuthenticationSpec.groovy
+++ b/src/test/groovy/org/ajoberstar/grgit/auth/MacAuthenticationSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/groovy/org/ajoberstar/grgit/auth/WindowsAuthenticationSpec.groovy
+++ b/src/test/groovy/org/ajoberstar/grgit/auth/WindowsAuthenticationSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/groovy/org/ajoberstar/grgit/fixtures/Categories.groovy
+++ b/src/test/groovy/org/ajoberstar/grgit/fixtures/Categories.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/groovy/org/ajoberstar/grgit/fixtures/GitTestUtil.groovy
+++ b/src/test/groovy/org/ajoberstar/grgit/fixtures/GitTestUtil.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/groovy/org/ajoberstar/grgit/fixtures/MultiGitOpSpec.groovy
+++ b/src/test/groovy/org/ajoberstar/grgit/fixtures/MultiGitOpSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/groovy/org/ajoberstar/grgit/fixtures/SimpleGitOpSpec.groovy
+++ b/src/test/groovy/org/ajoberstar/grgit/fixtures/SimpleGitOpSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/groovy/org/ajoberstar/grgit/operation/AddOpSpec.groovy
+++ b/src/test/groovy/org/ajoberstar/grgit/operation/AddOpSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/groovy/org/ajoberstar/grgit/operation/ApplyOpSpec.groovy
+++ b/src/test/groovy/org/ajoberstar/grgit/operation/ApplyOpSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/groovy/org/ajoberstar/grgit/operation/BranchAddOpSpec.groovy
+++ b/src/test/groovy/org/ajoberstar/grgit/operation/BranchAddOpSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/groovy/org/ajoberstar/grgit/operation/BranchChangeOpSpec.groovy
+++ b/src/test/groovy/org/ajoberstar/grgit/operation/BranchChangeOpSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/groovy/org/ajoberstar/grgit/operation/BranchListOpSpec.groovy
+++ b/src/test/groovy/org/ajoberstar/grgit/operation/BranchListOpSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/groovy/org/ajoberstar/grgit/operation/BranchRemoveOpSpec.groovy
+++ b/src/test/groovy/org/ajoberstar/grgit/operation/BranchRemoveOpSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/groovy/org/ajoberstar/grgit/operation/BranchStatusOpSpec.groovy
+++ b/src/test/groovy/org/ajoberstar/grgit/operation/BranchStatusOpSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/groovy/org/ajoberstar/grgit/operation/CheckoutOpSpec.groovy
+++ b/src/test/groovy/org/ajoberstar/grgit/operation/CheckoutOpSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/groovy/org/ajoberstar/grgit/operation/CleanOpSpec.groovy
+++ b/src/test/groovy/org/ajoberstar/grgit/operation/CleanOpSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/groovy/org/ajoberstar/grgit/operation/CloneOpSpec.groovy
+++ b/src/test/groovy/org/ajoberstar/grgit/operation/CloneOpSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/groovy/org/ajoberstar/grgit/operation/CommitOpSpec.groovy
+++ b/src/test/groovy/org/ajoberstar/grgit/operation/CommitOpSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/groovy/org/ajoberstar/grgit/operation/DescribeOpSpec.groovy
+++ b/src/test/groovy/org/ajoberstar/grgit/operation/DescribeOpSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/groovy/org/ajoberstar/grgit/operation/FetchOpSpec.groovy
+++ b/src/test/groovy/org/ajoberstar/grgit/operation/FetchOpSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/groovy/org/ajoberstar/grgit/operation/InitOpSpec.groovy
+++ b/src/test/groovy/org/ajoberstar/grgit/operation/InitOpSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/groovy/org/ajoberstar/grgit/operation/LogOpSpec.groovy
+++ b/src/test/groovy/org/ajoberstar/grgit/operation/LogOpSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/groovy/org/ajoberstar/grgit/operation/LsRemoteOpSpec.groovy
+++ b/src/test/groovy/org/ajoberstar/grgit/operation/LsRemoteOpSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/groovy/org/ajoberstar/grgit/operation/LsRemoteOpSpec.groovy
+++ b/src/test/groovy/org/ajoberstar/grgit/operation/LsRemoteOpSpec.groovy
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2012-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ajoberstar.grgit.operation
+
+import org.ajoberstar.grgit.Grgit
+import org.ajoberstar.grgit.Ref
+import org.ajoberstar.grgit.exception.GrgitException
+import org.ajoberstar.grgit.fixtures.MultiGitOpSpec
+
+import spock.lang.Unroll
+
+class LsRemoteOpSpec extends MultiGitOpSpec {
+  Grgit localGrgit
+  Grgit remoteGrgit
+
+  List branches = []
+  List tags = []
+
+  def setup() {
+    remoteGrgit = init('remote')
+
+    branches << remoteGrgit.branch.current
+
+    repoFile(remoteGrgit, '1.txt') << '1'
+    remoteGrgit.commit(message: 'do', all: true)
+
+    branches << remoteGrgit.branch.add(name: 'my-branch')
+
+    localGrgit = clone('local', remoteGrgit)
+
+    repoFile(remoteGrgit, '1.txt') << '2'
+    remoteGrgit.commit(message: 'do', all: true)
+
+    tags << remoteGrgit.tag.add(name: 'reachable-tag')
+    branches << remoteGrgit.branch.add(name: 'sub/mine1')
+
+    remoteGrgit.checkout {
+      branch = 'unreachable-branch'
+      createBranch = true
+    }
+    branches << remoteGrgit.branch.list().find { it.name == 'unreachable-branch' }
+
+    repoFile(remoteGrgit, '1.txt') << '2.5'
+    remoteGrgit.commit(message: 'do-unreachable', all: true)
+
+    tags << remoteGrgit.tag.add(name: 'unreachable-tag')
+
+    remoteGrgit.checkout(branch: 'master')
+
+    repoFile(remoteGrgit, '1.txt') << '3'
+    remoteGrgit.commit(message: 'do', all: true)
+
+    branches << remoteGrgit.branch.add(name: 'sub/mine2')
+
+    println remoteGrgit.branch.list()
+    println remoteGrgit.tag.list()
+  }
+
+  def 'lsremote from non-existent remote fails'() {
+    when:
+    localGrgit.lsremote(remote: 'fake')
+    then:
+    thrown(GrgitException)
+  }
+
+  def 'lsremote returns all refs'() {
+    expect:
+    localGrgit.lsremote() == format([new Ref('HEAD'), branches, tags].flatten())
+  }
+
+  def 'lsremote returns branches and tags'() {
+    expect:
+    localGrgit.lsremote(heads: true, tags: true) == format([branches, tags].flatten())
+  }
+
+  def 'lsremote returns only branches'() {
+    expect:
+    localGrgit.lsremote(heads: true) == format(branches)
+  }
+
+  def 'lsremote returns only tags'() {
+    expect:
+    localGrgit.lsremote(tags: true) == format(tags)
+  }
+
+  private Map format(things) {
+    return things.collectEntries { refish ->
+      Ref ref = new Ref(refish.fullName)
+      [(ref): remoteGrgit.resolve.toObjectId(refish)]
+    }
+  }
+}

--- a/src/test/groovy/org/ajoberstar/grgit/operation/MergeOpSpec.groovy
+++ b/src/test/groovy/org/ajoberstar/grgit/operation/MergeOpSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/groovy/org/ajoberstar/grgit/operation/OpenOpSpec.groovy
+++ b/src/test/groovy/org/ajoberstar/grgit/operation/OpenOpSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/groovy/org/ajoberstar/grgit/operation/PullOpSpec.groovy
+++ b/src/test/groovy/org/ajoberstar/grgit/operation/PullOpSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/groovy/org/ajoberstar/grgit/operation/PushOpSpec.groovy
+++ b/src/test/groovy/org/ajoberstar/grgit/operation/PushOpSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/groovy/org/ajoberstar/grgit/operation/RemoteAddOpSpec.groovy
+++ b/src/test/groovy/org/ajoberstar/grgit/operation/RemoteAddOpSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/groovy/org/ajoberstar/grgit/operation/RemoteListOpSpec.groovy
+++ b/src/test/groovy/org/ajoberstar/grgit/operation/RemoteListOpSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/groovy/org/ajoberstar/grgit/operation/ResetOpSpec.groovy
+++ b/src/test/groovy/org/ajoberstar/grgit/operation/ResetOpSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/groovy/org/ajoberstar/grgit/operation/RevertOpSpec.groovy
+++ b/src/test/groovy/org/ajoberstar/grgit/operation/RevertOpSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/groovy/org/ajoberstar/grgit/operation/RmOpSpec.groovy
+++ b/src/test/groovy/org/ajoberstar/grgit/operation/RmOpSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/groovy/org/ajoberstar/grgit/operation/ShowOpSpec.groovy
+++ b/src/test/groovy/org/ajoberstar/grgit/operation/ShowOpSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/groovy/org/ajoberstar/grgit/operation/StatusOpSpec.groovy
+++ b/src/test/groovy/org/ajoberstar/grgit/operation/StatusOpSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/groovy/org/ajoberstar/grgit/operation/TagAddOpSpec.groovy
+++ b/src/test/groovy/org/ajoberstar/grgit/operation/TagAddOpSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/groovy/org/ajoberstar/grgit/operation/TagAddOpSpec.groovy
+++ b/src/test/groovy/org/ajoberstar/grgit/operation/TagAddOpSpec.groovy
@@ -15,6 +15,11 @@
  */
 package org.ajoberstar.grgit.operation
 
+import java.time.Instant
+import java.time.ZoneId
+import java.time.ZonedDateTime
+import java.time.temporal.ChronoField
+
 import org.ajoberstar.grgit.Tag
 import org.ajoberstar.grgit.exception.GrgitException
 import org.ajoberstar.grgit.fixtures.SimpleGitOpSpec
@@ -34,6 +39,10 @@ class TagAddOpSpec extends SimpleGitOpSpec {
   }
 
   def 'tag add creates annotated tag pointing to current HEAD'() {
+    given:
+    Instant instant = Instant.now().with(ChronoField.NANO_OF_SECOND, 0)
+    ZoneId zone = ZoneId.ofOffset('GMT', ZoneId.systemDefault().getRules().getOffset(instant))
+    ZonedDateTime tagTime = ZonedDateTime.ofInstant(instant, zone)
     when:
     grgit.tag.add(name: 'test-tag')
     then:
@@ -42,7 +51,8 @@ class TagAddOpSpec extends SimpleGitOpSpec {
       person,
       'refs/tags/test-tag',
       '',
-      ''
+      '',
+      tagTime
     )]
     grgit.resolve.toCommit('test-tag') == grgit.head()
   }
@@ -56,12 +66,17 @@ class TagAddOpSpec extends SimpleGitOpSpec {
       null,
       'refs/tags/test-tag',
       null,
-      null
+      null,
+    null
     )]
     grgit.resolve.toCommit('test-tag') == grgit.head()
   }
 
   def 'tag add with name and pointsTo creates tag pointing to pointsTo'() {
+    given:
+    Instant instant = Instant.now().with(ChronoField.NANO_OF_SECOND, 0)
+    ZoneId zone = ZoneId.ofOffset('GMT', ZoneId.systemDefault().getRules().getOffset(instant))
+    ZonedDateTime tagTime = ZonedDateTime.ofInstant(instant, zone)
     when:
     grgit.tag.add(name: 'test-tag', pointsTo: commits[0].id)
     then:
@@ -70,7 +85,8 @@ class TagAddOpSpec extends SimpleGitOpSpec {
       person,
       'refs/tags/test-tag',
       '',
-      ''
+      '',
+      tagTime
     )]
     grgit.resolve.toCommit('test-tag') == commits[0]
   }

--- a/src/test/groovy/org/ajoberstar/grgit/operation/TagListOpSpec.groovy
+++ b/src/test/groovy/org/ajoberstar/grgit/operation/TagListOpSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/groovy/org/ajoberstar/grgit/operation/TagListOpSpec.groovy
+++ b/src/test/groovy/org/ajoberstar/grgit/operation/TagListOpSpec.groovy
@@ -20,25 +20,22 @@ import org.ajoberstar.grgit.fixtures.SimpleGitOpSpec
 
 class TagListOpSpec extends SimpleGitOpSpec {
   List commits = []
+  List tags = []
 
   def setup() {
     repoFile('1.txt') << '1'
     commits << grgit.commit(message: 'do', all: true)
-    grgit.tag.add(name: 'tag1', message: 'My message')
+    tags << grgit.tag.add(name: 'tag1', message: 'My message')
 
     repoFile('1.txt') << '2'
     commits << grgit.commit(message: 'do', all: true)
-    grgit.tag.add(name: 'tag2', message: 'My other\nmessage')
+    tags << grgit.tag.add(name: 'tag2', message: 'My other\nmessage')
 
-    grgit.tag.add(name: 'tag3', message: 'My next message.', pointsTo: 'tag1')
+    tags << grgit.tag.add(name: 'tag3', message: 'My next message.', pointsTo: 'tag1')
   }
 
   def 'tag list lists all tags'() {
     expect:
-    grgit.tag.list() == [
-      new Tag(commits[0], person, 'refs/tags/tag1', 'My message', 'My message'),
-      new Tag(commits[1], person, 'refs/tags/tag2', 'My other\nmessage', 'My other message'),
-      new Tag(commits[0], person, 'refs/tags/tag3', 'My next message.', 'My next message.')
-    ]
+    grgit.tag.list() == tags
   }
 }

--- a/src/test/groovy/org/ajoberstar/grgit/operation/TagRemoveOpSpec.groovy
+++ b/src/test/groovy/org/ajoberstar/grgit/operation/TagRemoveOpSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/groovy/org/ajoberstar/grgit/util/JGitUtilSpec.groovy
+++ b/src/test/groovy/org/ajoberstar/grgit/util/JGitUtilSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Now that Java 8 is required, we can use java.time classes. Both Commit
and Tag now support a dateTime field that uses a ZonedDateTime class.
The old time and date on Commit are now deprecated in favor of this new
field.

This resolves #166.