### PR TITLE
Adding org.ajoberstar.grgit Gradle plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 plugins {
   id 'org.ajoberstar.defaults' version '0.7.3'
+  id 'java-gradle-plugin'
   id 'groovy'
 }
 
@@ -18,6 +19,9 @@ dependencies {
   // groovy
   compileOnly 'org.codehaus.groovy:groovy-all:2.4.12'
   testCompile 'org.codehaus.groovy:groovy-all:2.4.12'
+
+  // gradle
+  compileOnly gradleApi()
 
   // jgit
   compile "org.eclipse.jgit:org.eclipse.jgit:$jgitVersion"
@@ -63,6 +67,24 @@ model {
     repo = 'maven'
     pkg = 'grgit'
   }
+}
+
+pluginBundle {
+    website = 'https://github.com/ajoberstar/grgit'
+    vcsUrl = 'https://github.com/ajoberstar/grgit.git'
+    description = 'The Groovy way to use Git'
+    plugins {
+        publishPlugin {
+            id = 'org.ajoberstar.grgit'
+            displayName = 'The Groovy way to use Git'
+            tags = ['git', 'groovy']
+        }
+    }
+    mavenCoordinates {
+        groupId = project.group
+        artifactId = project.name
+        version = project.version
+    }
 }
 
 wrapper {

--- a/build.gradle
+++ b/build.gradle
@@ -15,10 +15,18 @@ repositories {
 
 def jgitVersion = '4.8.0.201706111038-r'
 
+sourceSets {
+  compatTest {
+    compileClasspath += main.output
+    runtimeClasspath += main.output
+  }
+}
+
+configurations.compatTestCompile.extendsFrom configurations.compile
+
 dependencies {
   // groovy
   compileOnly 'org.codehaus.groovy:groovy-all:2.4.12'
-  testCompile 'org.codehaus.groovy:groovy-all:2.4.12'
 
   // gradle
   compileOnly gradleApi()
@@ -39,7 +47,8 @@ dependencies {
   testRuntime 'org.slf4j:slf4j-simple:1.7.25'
 
   // testing
-  testCompile('org.spockframework:spock-core:1.0-groovy-2.4') { exclude group: 'org.codehaus.groovy' }
+  testCompile('org.spockframework:spock-core:1.1-groovy-2.4')
+  compatTestCompile('org.spockframework:spock-core:1.1-groovy-2.4')
 }
 
 test {
@@ -59,6 +68,10 @@ test {
       }
     }
   }
+}
+
+stutter {
+    supports '3.0', '3.1', '3.2', '3.2.1', '3.3', '3.4', '3.5', '3.5.1', '4.0', '4.0.1', '4.0.2', '4.1-rc-1'
 }
 
 model {

--- a/src/compatTest/groovy/org/ajoberstar/grgit/gradle/BaseCompatTest.groovy
+++ b/src/compatTest/groovy/org/ajoberstar/grgit/gradle/BaseCompatTest.groovy
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.ajoberstar.grgit.gradle
 
 import spock.lang.Specification

--- a/src/compatTest/groovy/org/ajoberstar/grgit/gradle/BaseCompatTest.groovy
+++ b/src/compatTest/groovy/org/ajoberstar/grgit/gradle/BaseCompatTest.groovy
@@ -1,0 +1,84 @@
+package org.ajoberstar.grgit.gradle
+
+import spock.lang.Specification
+import spock.lang.Unroll
+
+import org.ajoberstar.grgit.Grgit
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.BuildResult
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+
+class BaseCompatTest extends Specification {
+  @Rule TemporaryFolder tempDir = new TemporaryFolder()
+  File projectDir
+  File buildFile
+
+  def setup() {
+    projectDir = tempDir.newFolder('project')
+    buildFile = projectFile('build.gradle')
+
+  }
+
+  def 'with no repo, plugin sets grgit to null'() {
+    given:
+    buildFile << '''\
+plugins {
+  id 'org.ajoberstar.grgit'
+}
+
+task doStuff {
+  doLast {
+    assert grgit == null
+  }
+}
+'''
+    when:
+    def result = build('doStuff')
+    then:
+    result.task(':doStuff').outcome == TaskOutcome.SUCCESS
+  }
+
+  def 'with repo, plugin opens the repo as grgit'() {
+    given:
+    Grgit git = Grgit.init(dir: projectDir)
+    projectFile('1.txt') << '1'
+    git.add(patterns: ['1.txt'])
+    git.commit(message: 'yay')
+    git.tag.add(name: '1.0.0')
+
+    buildFile << '''\
+plugins {
+  id 'org.ajoberstar.grgit'
+}
+
+task doStuff {
+  doLast {
+    println grgit.describe()
+  }
+}
+'''
+    when:
+    def result = build('doStuff', '--quiet')
+    then:
+    result.task(':doStuff').outcome == TaskOutcome.SUCCESS
+    result.output.normalize() == '1.0.0\n'
+  }
+
+  private BuildResult build(String... args) {
+    return GradleRunner.create()
+      .withGradleVersion(System.properties['compat.gradle.version'])
+      .withPluginClasspath()
+      .withProjectDir(projectDir)
+      .forwardOutput()
+      .withArguments((args + '--stacktrace') as String[])
+      .build()
+  }
+
+  private File projectFile(String path) {
+    File file = new File(projectDir, path)
+    file.parentFile.mkdirs()
+    return file
+  }
+}

--- a/src/main/groovy/org/ajoberstar/grgit/gradle/GrgitPlugin.groovy
+++ b/src/main/groovy/org/ajoberstar/grgit/gradle/GrgitPlugin.groovy
@@ -46,8 +46,9 @@ class GrgitPlugin implements Plugin<Project> {
         }
         prj.ext.grgit = grgit
       }
-    } catch (Exception ignored) {
-      project.logger.error('No git repository found for ${project.path}. Accessing grgit will cause an NPE.')
+    } catch (Exception e) {
+      project.logger.error("No git repository found for ${project.path}. Accessing grgit will cause an NPE.")
+      project.logger.debug("Failed trying to find git repository for ${project.path}", e)
       project.ext.grgit = null
     }
   }

--- a/src/main/groovy/org/ajoberstar/grgit/gradle/GrgitPlugin.groovy
+++ b/src/main/groovy/org/ajoberstar/grgit/gradle/GrgitPlugin.groovy
@@ -18,7 +18,6 @@ package org.ajoberstar.grgit.gradle
 import org.ajoberstar.grgit.Grgit
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.api.Task
 
 /**
  * Plugin adding a {@code grgit} property to all projects
@@ -27,8 +26,6 @@ import org.gradle.api.Task
  * @since 2.0.0
  */
 class GrgitPlugin implements Plugin<Project> {
-  private static final String CLOSE_TASK = 'gitClose'
-
   @Override
   void apply(Project project) {
     try {

--- a/src/main/groovy/org/ajoberstar/grgit/gradle/GrgitPlugin.groovy
+++ b/src/main/groovy/org/ajoberstar/grgit/gradle/GrgitPlugin.groovy
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2012-2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ajoberstar.grgit.gradle
+
+import org.ajoberstar.grgit.Grgit
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.Task
+
+/**
+ * Plugin adding a {@code grgit} property to all projects
+ * that searches for a Git repo from the project's
+ * directory.
+ * @since 2.0.0
+ */
+class GrgitPlugin implements Plugin<Project> {
+  private static final String CLOSE_TASK = 'gitClose'
+
+  @Override
+  void apply(Project project) {
+    try {
+      Grgit grgit = Grgit.open(currentDir: project.rootDir)
+
+      Task closeTask = createCloseTask(project, grgit)
+
+      project.allprojects { prj ->
+        if (prj.ext.has('grgit')) {
+          prj.logger.warn("Project ${prj.path} already has a grgit property. Remove org.ajoberstar.grgit from either ${prj.path} or ${project.path}.")
+        }
+
+        prj.ext.grgit = grgit
+
+        prj.tasks.all { task ->
+          if (task.name != CLOSE_TASK) {
+            task.finalizedBy(closeTask)
+          }
+        }
+      }
+    } catch (Exception ignored) {
+      project.logger.error('No git repository found for ${project.path}. Accessing grgit will cause an NPE.')
+      project.ext.grgit = null
+    }
+  }
+
+  private Task createCloseTask(Project project, Grgit grgit) {
+    Task task = project.tasks.create(CLOSE_TASK)
+    task.doLast {
+      grgit.close()
+    }
+    return task
+  }
+}

--- a/src/main/groovy/org/ajoberstar/grgit/internal/OpSyntax.groovy
+++ b/src/main/groovy/org/ajoberstar/grgit/internal/OpSyntax.groovy
@@ -16,7 +16,6 @@
 package org.ajoberstar.grgit.internal
 
 import java.util.concurrent.Callable
-import java.util.function.Consumer
 
 import groovy.transform.PackageScope
 
@@ -33,12 +32,6 @@ class OpSyntax {
       op[key] = value
     }
 
-    return op.call()
-  }
-
-  static def consumerOperation(Class<Callable> opClass, Object[] classArgs, Consumer arg) {
-    def op = opClass.newInstance(classArgs)
-    arg.accept(op)
     return op.call()
   }
 

--- a/src/main/groovy/org/ajoberstar/grgit/internal/OpSyntax.groovy
+++ b/src/main/groovy/org/ajoberstar/grgit/internal/OpSyntax.groovy
@@ -17,8 +17,6 @@ package org.ajoberstar.grgit.internal
 
 import java.util.concurrent.Callable
 
-import groovy.transform.PackageScope
-
 class OpSyntax {
   static def noArgOperation(Class<Callable> opClass, Object[] classArgs) {
     def op = opClass.newInstance(classArgs)

--- a/src/main/groovy/org/ajoberstar/grgit/internal/WithOperationsASTTransformation.java
+++ b/src/main/groovy/org/ajoberstar/grgit/internal/WithOperationsASTTransformation.java
@@ -61,14 +61,8 @@ public class WithOperationsASTTransformation extends AbstractASTTransformation {
       List<ClassNode> staticOps = getClassList(annotation, "staticOperations");
       List<ClassNode> instanceOps = getClassList(annotation, "instanceOperations");
 
-      staticOps.forEach(
-          op -> {
-            makeMethods(clazz, op, true);
-          });
-      instanceOps.forEach(
-          op -> {
-            makeMethods(clazz, op, false);
-          });
+      staticOps.forEach(op -> makeMethods(clazz, op, true));
+      instanceOps.forEach(op -> makeMethods(clazz, op, false));
     }
   }
 

--- a/src/main/groovy/org/ajoberstar/grgit/internal/WithOperationsASTTransformation.java
+++ b/src/main/groovy/org/ajoberstar/grgit/internal/WithOperationsASTTransformation.java
@@ -22,7 +22,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Consumer;
 
 import org.codehaus.groovy.ast.ASTNode;
 import org.codehaus.groovy.ast.AnnotatedNode;
@@ -88,7 +87,6 @@ public class WithOperationsASTTransformation extends AbstractASTTransformation {
 
     targetClass.addMethod(makeNoArgMethod(targetClass, opName, opClass, opReturn, isStatic));
     targetClass.addMethod(makeMapMethod(targetClass, opName, opClass, opReturn, isStatic));
-    targetClass.addMethod(makeConsumerMethod(targetClass, opName, opClass, opReturn, isStatic));
     targetClass.addMethod(makeClosureMethod(targetClass, opName, opClass, opReturn, isStatic));
   }
 
@@ -134,31 +132,6 @@ public class WithOperationsASTTransformation extends AbstractASTTransformation {
                     new ArrayExpression(
                         classFromType(Object.class), opConstructorParms(targetClass, isStatic)),
                     new VariableExpression("args"))));
-
-    return new MethodNode(opName, modifiers(isStatic), opReturn, parms, new ClassNode[] {}, code);
-  }
-
-  private MethodNode makeConsumerMethod(
-      ClassNode targetClass,
-      String opName,
-      ClassNode opClass,
-      ClassNode opReturn,
-      boolean isStatic) {
-    ClassNode parmType = classFromType(Consumer.class);
-    GenericsType[] generics = new GenericsType[] {new GenericsType(opReturn)};
-    parmType.setGenericsTypes(generics);
-    Parameter[] parms = new Parameter[] {new Parameter(parmType, "arg")};
-
-    Statement code =
-        new ExpressionStatement(
-            new StaticMethodCallExpression(
-                classFromType(OpSyntax.class),
-                "consumerOperation",
-                new ArgumentListExpression(
-                    new ClassExpression(opClass),
-                    new ArrayExpression(
-                        classFromType(Object.class), opConstructorParms(targetClass, isStatic)),
-                    new VariableExpression("arg"))));
 
     return new MethodNode(opName, modifiers(isStatic), opReturn, parms, new ClassNode[] {}, code);
   }

--- a/src/main/resources/META-INF/gradle-plugins/org.ajoberstar.grgit.properties
+++ b/src/main/resources/META-INF/gradle-plugins/org.ajoberstar.grgit.properties
@@ -1,0 +1,1 @@
+implementation-class=org.ajoberstar.grgit.gradle.GrgitPlugin


### PR DESCRIPTION
This is being migrated from gradle-git. Differences from 1.7.x
gradle-git:

- Allow applying to projects besides the rootProject
- Warn if project was applied to root project and a subproject
- Add a close task that finalizes all other tasks

This resolves #178.