### PR TITLE
Configure credentials on lsremote

### DIFF
--- a/src/main/groovy/org/ajoberstar/grgit/operation/LsRemoteOp.groovy
+++ b/src/main/groovy/org/ajoberstar/grgit/operation/LsRemoteOp.groovy
@@ -4,6 +4,7 @@ import java.util.concurrent.Callable
 
 import org.ajoberstar.grgit.Ref
 import org.ajoberstar.grgit.Repository
+import org.ajoberstar.grgit.auth.TransportOpUtil
 import org.ajoberstar.grgit.internal.Operation
 import org.eclipse.jgit.api.LsRemoteCommand
 import org.eclipse.jgit.lib.ObjectId
@@ -30,6 +31,7 @@ class LsRemoteOp implements Callable<Map<Ref, String>> {
 
   Map<Ref, String> call() {
     LsRemoteCommand cmd = repo.jgit.lsRemote()
+    TransportOpUtil.configure(cmd, repo.credentials)
     cmd.remote = remote
     cmd.heads = heads
     cmd.tags = tags


### PR DESCRIPTION
Credentials were not being configured on lsremote, unlike all other
TransportCommands that were being used.

This fixes #222.