### PR TITLE
Generate correct Consumer type for ops

### DIFF
--- a/src/main/groovy/org/ajoberstar/grgit/internal/WithOperationsASTTransformation.java
+++ b/src/main/groovy/org/ajoberstar/grgit/internal/WithOperationsASTTransformation.java
@@ -101,7 +101,7 @@ public class WithOperationsASTTransformation extends AbstractASTTransformation {
 
   private MethodNode makeConsumerMethod(ClassNode targetClass, String opName, ClassNode opClass, ClassNode opReturn, boolean isStatic) {
     ClassNode parmType = classFromType(Consumer.class);
-    GenericsType[] generics = new GenericsType[] {new GenericsType(opReturn)};
+    GenericsType[] generics = new GenericsType[] {new GenericsType(opClass)};
     parmType.setGenericsTypes(generics);
     Parameter[] parms = new Parameter[] {new Parameter(parmType, "arg")};
 

--- a/src/test/groovy/org/ajoberstar/grgit/operation/GenericOpTest.java
+++ b/src/test/groovy/org/ajoberstar/grgit/operation/GenericOpTest.java
@@ -1,0 +1,32 @@
+package org.ajoberstar.grgit.operation;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashSet;
+import org.junit.Test;
+import static org.junit.Assert.*;
+import org.junit.Rule;
+import org.junit.rules.TemporaryFolder;
+import org.ajoberstar.grgit.Grgit;
+
+public class GenericOpTest {
+  @Rule
+  public TemporaryFolder tempDir = new TemporaryFolder();
+
+  @Test
+  public void consumerOperationWorks() throws IOException {
+    File dir = tempDir.newFolder();
+    Grgit grgit = Grgit.init(op -> {
+      op.setDir(dir);
+    });
+    grgit.add(op -> {
+      op.setPatterns(new HashSet<>(Arrays.asList(".")));
+    });
+    grgit.commit(op -> {
+      op.setMessage("First commit");
+    });
+    assertEquals(1, grgit.log().size());
+    grgit.close();
+  }
+}


### PR DESCRIPTION
Incorrectly generating Consumer<Return> instead of Consumer<Op>. e.g.
for Grgit.commit() which returns a Commit, we generated Consumer<Commit>
instead of Consumer<CommitOp>. This now allows you to correctly use
Consumers as an option.