### PR TITLE
Publish static versions in plugin POM

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id 'org.ajoberstar.defaults' version '0.11.0'
+  id 'org.ajoberstar.defaults' version '0.11.1'
   id 'org.jbake.site' version '1.0.0'
   id 'java-gradle-plugin'
   id 'groovy'
@@ -64,7 +64,7 @@ dependencies {
   compileOnly gradleApi()
 
   // jgit
-  def jgitVersion = '[4.8.0.201706111038-r,)'
+  def jgitVersion = '[4.11.0.201803080745-r, 5.0)'
   compile "org.eclipse.jgit:org.eclipse.jgit:$jgitVersion"
   compile "org.eclipse.jgit:org.eclipse.jgit.ui:$jgitVersion"
 

--- a/global.lock
+++ b/global.lock
@@ -34,11 +34,11 @@
         },
         "org.eclipse.jgit:org.eclipse.jgit": {
             "locked": "4.11.0.201803080745-r",
-            "requested": "[4.8.0.201706111038-r,)"
+            "requested": "[4.11.0.201803080745-r, 5.0)"
         },
         "org.eclipse.jgit:org.eclipse.jgit.ui": {
             "locked": "4.11.0.201803080745-r",
-            "requested": "[4.8.0.201706111038-r,)"
+            "requested": "[4.11.0.201803080745-r, 5.0)"
         },
         "org.spockframework:spock-core": {
             "locked": "1.1-groovy-2.4",
@@ -80,11 +80,11 @@
         },
         "org.eclipse.jgit:org.eclipse.jgit": {
             "locked": "4.11.0.201803080745-r",
-            "requested": "[4.8.0.201706111038-r,)"
+            "requested": "[4.11.0.201803080745-r, 5.0)"
         },
         "org.eclipse.jgit:org.eclipse.jgit.ui": {
             "locked": "4.11.0.201803080745-r",
-            "requested": "[4.8.0.201706111038-r,)"
+            "requested": "[4.11.0.201803080745-r, 5.0)"
         },
         "org.spockframework:spock-core": {
             "locked": "1.1-groovy-2.4",
@@ -126,11 +126,11 @@
         },
         "org.eclipse.jgit:org.eclipse.jgit": {
             "locked": "4.11.0.201803080745-r",
-            "requested": "[4.8.0.201706111038-r,)"
+            "requested": "[4.11.0.201803080745-r, 5.0)"
         },
         "org.eclipse.jgit:org.eclipse.jgit.ui": {
             "locked": "4.11.0.201803080745-r",
-            "requested": "[4.8.0.201706111038-r,)"
+            "requested": "[4.11.0.201803080745-r, 5.0)"
         },
         "org.spockframework:spock-core": {
             "locked": "1.1-groovy-2.4",
@@ -172,11 +172,11 @@
         },
         "org.eclipse.jgit:org.eclipse.jgit": {
             "locked": "4.11.0.201803080745-r",
-            "requested": "[4.8.0.201706111038-r,)"
+            "requested": "[4.11.0.201803080745-r, 5.0)"
         },
         "org.eclipse.jgit:org.eclipse.jgit.ui": {
             "locked": "4.11.0.201803080745-r",
-            "requested": "[4.8.0.201706111038-r,)"
+            "requested": "[4.11.0.201803080745-r, 5.0)"
         },
         "org.spockframework:spock-core": {
             "locked": "1.1-groovy-2.4",
@@ -214,11 +214,11 @@
         },
         "org.eclipse.jgit:org.eclipse.jgit": {
             "locked": "4.11.0.201803080745-r",
-            "requested": "[4.8.0.201706111038-r,)"
+            "requested": "[4.11.0.201803080745-r, 5.0)"
         },
         "org.eclipse.jgit:org.eclipse.jgit.ui": {
             "locked": "4.11.0.201803080745-r",
-            "requested": "[4.8.0.201706111038-r,)"
+            "requested": "[4.11.0.201803080745-r, 5.0)"
         }
     },
     "compileClasspath": {
@@ -252,11 +252,11 @@
         },
         "org.eclipse.jgit:org.eclipse.jgit": {
             "locked": "4.11.0.201803080745-r",
-            "requested": "[4.8.0.201706111038-r,)"
+            "requested": "[4.11.0.201803080745-r, 5.0)"
         },
         "org.eclipse.jgit:org.eclipse.jgit.ui": {
             "locked": "4.11.0.201803080745-r",
-            "requested": "[4.8.0.201706111038-r,)"
+            "requested": "[4.11.0.201803080745-r, 5.0)"
         }
     },
     "default": {
@@ -290,11 +290,11 @@
         },
         "org.eclipse.jgit:org.eclipse.jgit": {
             "locked": "4.11.0.201803080745-r",
-            "requested": "[4.8.0.201706111038-r,)"
+            "requested": "[4.11.0.201803080745-r, 5.0)"
         },
         "org.eclipse.jgit:org.eclipse.jgit.ui": {
             "locked": "4.11.0.201803080745-r",
-            "requested": "[4.8.0.201706111038-r,)"
+            "requested": "[4.11.0.201803080745-r, 5.0)"
         }
     },
     "jbake": {
@@ -358,11 +358,11 @@
         },
         "org.eclipse.jgit:org.eclipse.jgit": {
             "locked": "4.11.0.201803080745-r",
-            "requested": "[4.8.0.201706111038-r,)"
+            "requested": "[4.11.0.201803080745-r, 5.0)"
         },
         "org.eclipse.jgit:org.eclipse.jgit.ui": {
             "locked": "4.11.0.201803080745-r",
-            "requested": "[4.8.0.201706111038-r,)"
+            "requested": "[4.11.0.201803080745-r, 5.0)"
         }
     },
     "runtimeClasspath": {
@@ -396,11 +396,11 @@
         },
         "org.eclipse.jgit:org.eclipse.jgit": {
             "locked": "4.11.0.201803080745-r",
-            "requested": "[4.8.0.201706111038-r,)"
+            "requested": "[4.11.0.201803080745-r, 5.0)"
         },
         "org.eclipse.jgit:org.eclipse.jgit.ui": {
             "locked": "4.11.0.201803080745-r",
-            "requested": "[4.8.0.201706111038-r,)"
+            "requested": "[4.11.0.201803080745-r, 5.0)"
         }
     },
     "testCompile": {
@@ -442,11 +442,11 @@
         },
         "org.eclipse.jgit:org.eclipse.jgit": {
             "locked": "4.11.0.201803080745-r",
-            "requested": "[4.8.0.201706111038-r,)"
+            "requested": "[4.11.0.201803080745-r, 5.0)"
         },
         "org.eclipse.jgit:org.eclipse.jgit.ui": {
             "locked": "4.11.0.201803080745-r",
-            "requested": "[4.8.0.201706111038-r,)"
+            "requested": "[4.11.0.201803080745-r, 5.0)"
         },
         "org.slf4j:slf4j-api": {
             "locked": "1.7.25",
@@ -496,11 +496,11 @@
         },
         "org.eclipse.jgit:org.eclipse.jgit": {
             "locked": "4.11.0.201803080745-r",
-            "requested": "[4.8.0.201706111038-r,)"
+            "requested": "[4.11.0.201803080745-r, 5.0)"
         },
         "org.eclipse.jgit:org.eclipse.jgit.ui": {
             "locked": "4.11.0.201803080745-r",
-            "requested": "[4.8.0.201706111038-r,)"
+            "requested": "[4.11.0.201803080745-r, 5.0)"
         },
         "org.slf4j:slf4j-api": {
             "locked": "1.7.25",
@@ -550,11 +550,11 @@
         },
         "org.eclipse.jgit:org.eclipse.jgit": {
             "locked": "4.11.0.201803080745-r",
-            "requested": "[4.8.0.201706111038-r,)"
+            "requested": "[4.11.0.201803080745-r, 5.0)"
         },
         "org.eclipse.jgit:org.eclipse.jgit.ui": {
             "locked": "4.11.0.201803080745-r",
-            "requested": "[4.8.0.201706111038-r,)"
+            "requested": "[4.11.0.201803080745-r, 5.0)"
         },
         "org.slf4j:slf4j-api": {
             "locked": "1.7.25",
@@ -608,11 +608,11 @@
         },
         "org.eclipse.jgit:org.eclipse.jgit": {
             "locked": "4.11.0.201803080745-r",
-            "requested": "[4.8.0.201706111038-r,)"
+            "requested": "[4.11.0.201803080745-r, 5.0)"
         },
         "org.eclipse.jgit:org.eclipse.jgit.ui": {
             "locked": "4.11.0.201803080745-r",
-            "requested": "[4.8.0.201706111038-r,)"
+            "requested": "[4.11.0.201803080745-r, 5.0)"
         },
         "org.slf4j:slf4j-api": {
             "locked": "1.7.25",


### PR DESCRIPTION
The update defaults plugin has a fix for ensuring that POMs that go to
the plugin portal use static versions instead of ranges.