### PR TITLE
Use static JGit version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id 'org.ajoberstar.defaults' version '0.11.1'
+  id 'org.ajoberstar.defaults' version '0.11.0'
   id 'org.jbake.site' version '1.0.0'
   id 'java-gradle-plugin'
   id 'groovy'
@@ -64,7 +64,7 @@ dependencies {
   compileOnly gradleApi()
 
   // jgit
-  def jgitVersion = '[4.11.0.201803080745-r, 5.0)'
+  def jgitVersion = '4.11.0.201803080745-r'
   compile "org.eclipse.jgit:org.eclipse.jgit:$jgitVersion"
   compile "org.eclipse.jgit:org.eclipse.jgit.ui:$jgitVersion"
 

--- a/global.lock
+++ b/global.lock
@@ -34,11 +34,11 @@
         },
         "org.eclipse.jgit:org.eclipse.jgit": {
             "locked": "4.11.0.201803080745-r",
-            "requested": "[4.11.0.201803080745-r, 5.0)"
+            "requested": "4.11.0.201803080745-r"
         },
         "org.eclipse.jgit:org.eclipse.jgit.ui": {
             "locked": "4.11.0.201803080745-r",
-            "requested": "[4.11.0.201803080745-r, 5.0)"
+            "requested": "4.11.0.201803080745-r"
         },
         "org.spockframework:spock-core": {
             "locked": "1.1-groovy-2.4",
@@ -80,11 +80,11 @@
         },
         "org.eclipse.jgit:org.eclipse.jgit": {
             "locked": "4.11.0.201803080745-r",
-            "requested": "[4.11.0.201803080745-r, 5.0)"
+            "requested": "4.11.0.201803080745-r"
         },
         "org.eclipse.jgit:org.eclipse.jgit.ui": {
             "locked": "4.11.0.201803080745-r",
-            "requested": "[4.11.0.201803080745-r, 5.0)"
+            "requested": "4.11.0.201803080745-r"
         },
         "org.spockframework:spock-core": {
             "locked": "1.1-groovy-2.4",
@@ -126,11 +126,11 @@
         },
         "org.eclipse.jgit:org.eclipse.jgit": {
             "locked": "4.11.0.201803080745-r",
-            "requested": "[4.11.0.201803080745-r, 5.0)"
+            "requested": "4.11.0.201803080745-r"
         },
         "org.eclipse.jgit:org.eclipse.jgit.ui": {
             "locked": "4.11.0.201803080745-r",
-            "requested": "[4.11.0.201803080745-r, 5.0)"
+            "requested": "4.11.0.201803080745-r"
         },
         "org.spockframework:spock-core": {
             "locked": "1.1-groovy-2.4",
@@ -172,11 +172,11 @@
         },
         "org.eclipse.jgit:org.eclipse.jgit": {
             "locked": "4.11.0.201803080745-r",
-            "requested": "[4.11.0.201803080745-r, 5.0)"
+            "requested": "4.11.0.201803080745-r"
         },
         "org.eclipse.jgit:org.eclipse.jgit.ui": {
             "locked": "4.11.0.201803080745-r",
-            "requested": "[4.11.0.201803080745-r, 5.0)"
+            "requested": "4.11.0.201803080745-r"
         },
         "org.spockframework:spock-core": {
             "locked": "1.1-groovy-2.4",
@@ -214,11 +214,11 @@
         },
         "org.eclipse.jgit:org.eclipse.jgit": {
             "locked": "4.11.0.201803080745-r",
-            "requested": "[4.11.0.201803080745-r, 5.0)"
+            "requested": "4.11.0.201803080745-r"
         },
         "org.eclipse.jgit:org.eclipse.jgit.ui": {
             "locked": "4.11.0.201803080745-r",
-            "requested": "[4.11.0.201803080745-r, 5.0)"
+            "requested": "4.11.0.201803080745-r"
         }
     },
     "compileClasspath": {
@@ -252,11 +252,11 @@
         },
         "org.eclipse.jgit:org.eclipse.jgit": {
             "locked": "4.11.0.201803080745-r",
-            "requested": "[4.11.0.201803080745-r, 5.0)"
+            "requested": "4.11.0.201803080745-r"
         },
         "org.eclipse.jgit:org.eclipse.jgit.ui": {
             "locked": "4.11.0.201803080745-r",
-            "requested": "[4.11.0.201803080745-r, 5.0)"
+            "requested": "4.11.0.201803080745-r"
         }
     },
     "default": {
@@ -290,11 +290,11 @@
         },
         "org.eclipse.jgit:org.eclipse.jgit": {
             "locked": "4.11.0.201803080745-r",
-            "requested": "[4.11.0.201803080745-r, 5.0)"
+            "requested": "4.11.0.201803080745-r"
         },
         "org.eclipse.jgit:org.eclipse.jgit.ui": {
             "locked": "4.11.0.201803080745-r",
-            "requested": "[4.11.0.201803080745-r, 5.0)"
+            "requested": "4.11.0.201803080745-r"
         }
     },
     "jbake": {
@@ -358,11 +358,11 @@
         },
         "org.eclipse.jgit:org.eclipse.jgit": {
             "locked": "4.11.0.201803080745-r",
-            "requested": "[4.11.0.201803080745-r, 5.0)"
+            "requested": "4.11.0.201803080745-r"
         },
         "org.eclipse.jgit:org.eclipse.jgit.ui": {
             "locked": "4.11.0.201803080745-r",
-            "requested": "[4.11.0.201803080745-r, 5.0)"
+            "requested": "4.11.0.201803080745-r"
         }
     },
     "runtimeClasspath": {
@@ -396,11 +396,11 @@
         },
         "org.eclipse.jgit:org.eclipse.jgit": {
             "locked": "4.11.0.201803080745-r",
-            "requested": "[4.11.0.201803080745-r, 5.0)"
+            "requested": "4.11.0.201803080745-r"
         },
         "org.eclipse.jgit:org.eclipse.jgit.ui": {
             "locked": "4.11.0.201803080745-r",
-            "requested": "[4.11.0.201803080745-r, 5.0)"
+            "requested": "4.11.0.201803080745-r"
         }
     },
     "testCompile": {
@@ -442,11 +442,11 @@
         },
         "org.eclipse.jgit:org.eclipse.jgit": {
             "locked": "4.11.0.201803080745-r",
-            "requested": "[4.11.0.201803080745-r, 5.0)"
+            "requested": "4.11.0.201803080745-r"
         },
         "org.eclipse.jgit:org.eclipse.jgit.ui": {
             "locked": "4.11.0.201803080745-r",
-            "requested": "[4.11.0.201803080745-r, 5.0)"
+            "requested": "4.11.0.201803080745-r"
         },
         "org.slf4j:slf4j-api": {
             "locked": "1.7.25",
@@ -496,11 +496,11 @@
         },
         "org.eclipse.jgit:org.eclipse.jgit": {
             "locked": "4.11.0.201803080745-r",
-            "requested": "[4.11.0.201803080745-r, 5.0)"
+            "requested": "4.11.0.201803080745-r"
         },
         "org.eclipse.jgit:org.eclipse.jgit.ui": {
             "locked": "4.11.0.201803080745-r",
-            "requested": "[4.11.0.201803080745-r, 5.0)"
+            "requested": "4.11.0.201803080745-r"
         },
         "org.slf4j:slf4j-api": {
             "locked": "1.7.25",
@@ -550,11 +550,11 @@
         },
         "org.eclipse.jgit:org.eclipse.jgit": {
             "locked": "4.11.0.201803080745-r",
-            "requested": "[4.11.0.201803080745-r, 5.0)"
+            "requested": "4.11.0.201803080745-r"
         },
         "org.eclipse.jgit:org.eclipse.jgit.ui": {
             "locked": "4.11.0.201803080745-r",
-            "requested": "[4.11.0.201803080745-r, 5.0)"
+            "requested": "4.11.0.201803080745-r"
         },
         "org.slf4j:slf4j-api": {
             "locked": "1.7.25",
@@ -608,11 +608,11 @@
         },
         "org.eclipse.jgit:org.eclipse.jgit": {
             "locked": "4.11.0.201803080745-r",
-            "requested": "[4.11.0.201803080745-r, 5.0)"
+            "requested": "4.11.0.201803080745-r"
         },
         "org.eclipse.jgit:org.eclipse.jgit.ui": {
             "locked": "4.11.0.201803080745-r",
-            "requested": "[4.11.0.201803080745-r, 5.0)"
+            "requested": "4.11.0.201803080745-r"
         },
         "org.slf4j:slf4j-api": {
             "locked": "1.7.25",


### PR DESCRIPTION
Unfortunately nebula-maven-resolved-dependencies doesn't seem to put
static versions into the POM of com.gradle-plugin-publish artifacts. It
does affect everything I'm pushing to Bintray though. So we've been
using super permissive dependency ranges out to everyone and now, people
are being bit by a breaking change in JGit 5.

This fixes for #229 to just make the JGit dependency static.