### PR TITLE
Support groovy `withCloseable`

### DIFF
--- a/src/main/groovy/org/ajoberstar/grgit/Grgit.groovy
+++ b/src/main/groovy/org/ajoberstar/grgit/Grgit.groovy
@@ -96,7 +96,7 @@ import org.ajoberstar.grgit.util.JGitUtil
  * @since 0.1.0
  */
 @WithOperations(staticOperations=[InitOp, CloneOp, OpenOp], instanceOperations=[CleanOp, StatusOp, AddOp, RmOp, ResetOp, ApplyOp, PullOp, PushOp, FetchOp, LsRemoteOp, CheckoutOp, LogOp, CommitOp, RevertOp, MergeOp, DescribeOp, ShowOp])
-class Grgit implements AutoCloseable {
+class Grgit implements Closeable {
   /**
    * The repository opened by this object.
    */

--- a/src/test/groovy/org/ajoberstar/grgit/operation/OpenOpSpec.groovy
+++ b/src/test/groovy/org/ajoberstar/grgit/operation/OpenOpSpec.groovy
@@ -135,4 +135,15 @@ class OpenOpSpec extends SimpleGitOpSpec {
     then:
     opened.repository.rootDir.deleteDir()
   }
+
+  def 'opened repo is automatically closed in withCloseable'() {
+    given:
+    Grgit opened = Grgit.open(dir: repoDir('.').canonicalFile)
+    when:
+    opened.withCloseable {
+      it.log()
+    }
+    then:
+    opened.repository.rootDir.deleteDir()
+  }
 }


### PR DESCRIPTION
Altered Grgit to extend `Closeable` to allow groovy use of `withCloseable` to automatically close repository