### PR TITLE
Fix issue when reverting a commit results in a failingResult

### DIFF
--- a/src/main/groovy/org/ajoberstar/grgit/operation/RevertOp.groovy
+++ b/src/main/groovy/org/ajoberstar/grgit/operation/RevertOp.groovy
@@ -37,6 +37,9 @@ class RevertOp implements Callable<Commit> {
       cmd.include(JGitUtil.resolveObject(repo, revstr))
     }
     RevCommit commit = cmd.call()
+    if (cmd.failingResult) {
+      throw new IllegalStateException("Could not merge reverted commits (conflicting files can be retrieved with a call to grgit.status()): ${cmd.failingResult}")
+    }
     return JGitUtil.convertCommit(commit)
   }
 }

--- a/src/test/groovy/org/ajoberstar/grgit/operation/RevertOpSpec.groovy
+++ b/src/test/groovy/org/ajoberstar/grgit/operation/RevertOpSpec.groovy
@@ -27,4 +27,17 @@ class RevertOpSpec extends SimpleGitOpSpec {
     grgit.log().size() == 7
     repoFile('.').listFiles().collect { it.name }.findAll { !it.startsWith('.') } as Set == [0, 2, 4].collect { "${it}.txt" } as Set
   }
+
+  def 'revert with conflicts raises exception'() {
+    given:
+    repoFile("1.txt") << "Edited"
+    grgit.add(patterns:['.'])
+    commits << grgit.commit(message:'Modified', all: true)
+    when:
+    grgit.revert(commits:[1, 3].collect { commits[it].id })
+    then:
+    thrown(IllegalStateException)
+    grgit.log().size() == 6
+    grgit.status().conflicts.containsAll('1.txt')
+  }
 }


### PR DESCRIPTION
When a JGit`RevertCommand` fails, then a null RevCommit is returned from the call method (see https://github.com/eclipse/jgit/blob/master/org.eclipse.jgit/src/org/eclipse/jgit/api/RevertCommand.java#L219).

This PR adds a check for any failure modes and throws an exception (message shamelessly taken from `MergeOp`)