### PR TITLE
Ensure abbreviated commit IDs are unique

### DIFF
--- a/src/main/groovy/org/ajoberstar/grgit/Commit.groovy
+++ b/src/main/groovy/org/ajoberstar/grgit/Commit.groovy
@@ -15,6 +15,11 @@ class Commit {
   String id
 
   /**
+   * The abbreviated hash of the commit.
+   */
+  String abbreviatedId
+
+  /**
    * Hashes of any parent commits.
    */
   List<String> parentIds
@@ -67,9 +72,10 @@ class Commit {
   /**
    * The first {@code length} characters of the commit hash.
    * @param length the number of characters to abbreviate the
-   * hash to (defaults to 7)
+   * hash.
    */
-  String getAbbreviatedId(int length = 7) {
+  @Deprecated
+  String getAbbreviatedId(int length) {
     return id[0..(length - 1)]
   }
 }

--- a/src/main/groovy/org/ajoberstar/grgit/operation/CommitOp.groovy
+++ b/src/main/groovy/org/ajoberstar/grgit/operation/CommitOp.groovy
@@ -75,6 +75,6 @@ class CommitOp implements Callable<Commit> {
     if (all) { cmd.all = all }
     cmd.amend = amend
     RevCommit commit = cmd.call()
-    return JGitUtil.convertCommit(commit)
+    return JGitUtil.convertCommit(repo, commit)
   }
 }

--- a/src/main/groovy/org/ajoberstar/grgit/operation/LogOp.groovy
+++ b/src/main/groovy/org/ajoberstar/grgit/operation/LogOp.groovy
@@ -61,6 +61,6 @@ class LogOp implements Callable<List<Commit>> {
     }
     cmd.skip = skipCommits
     cmd.maxCount = maxCommits
-    return cmd.call().collect { JGitUtil.convertCommit(it) }.asImmutable()
+    return cmd.call().collect { JGitUtil.convertCommit(repo, it) }.asImmutable()
   }
 }

--- a/src/main/groovy/org/ajoberstar/grgit/operation/RevertOp.groovy
+++ b/src/main/groovy/org/ajoberstar/grgit/operation/RevertOp.groovy
@@ -40,6 +40,6 @@ class RevertOp implements Callable<Commit> {
     if (cmd.failingResult) {
       throw new IllegalStateException("Could not merge reverted commits (conflicting files can be retrieved with a call to grgit.status()): ${cmd.failingResult}")
     }
-    return JGitUtil.convertCommit(commit)
+    return JGitUtil.convertCommit(repo, commit)
   }
 }

--- a/src/main/groovy/org/ajoberstar/grgit/util/JGitUtil.groovy
+++ b/src/main/groovy/org/ajoberstar/grgit/util/JGitUtil.groovy
@@ -91,7 +91,7 @@ class JGitUtil {
    */
   static Commit resolveCommit(Repository repo, ObjectId id) {
     RevWalk walk = new RevWalk(repo.jgit.repository)
-    return convertCommit(walk.parseCommit(id))
+    return convertCommit(repo, walk.parseCommit(id))
   }
 
   /**
@@ -99,9 +99,10 @@ class JGitUtil {
    * @param rev the JGit commit to convert
    * @return a corresponding Grgit commit
    */
-  static Commit convertCommit(RevCommit rev) {
+  static Commit convertCommit(Repository repo, RevCommit rev) {
     Map props = [:]
     props.id = ObjectId.toString(rev)
+    props.abbreviatedId = repo.jgit.repository.newObjectReader().abbreviate(rev).name()
     PersonIdent committer = rev.committerIdent
     props.committer = new Person(committer.name, committer.emailAddress)
     PersonIdent author = rev.authorIdent
@@ -144,7 +145,7 @@ class JGitUtil {
       RevTag rev = walk.parseTag(ref.objectId)
       RevObject target = walk.peel(rev)
       walk.parseBody(rev.object)
-      props.commit = convertCommit(target)
+      props.commit = convertCommit(repo, target)
       PersonIdent tagger = rev.taggerIdent
       props.tagger = new Person(tagger.name, tagger.emailAddress)
       props.fullMessage = rev.fullMessage

--- a/src/test/groovy/org/ajoberstar/grgit/operation/LogOpSpec.groovy
+++ b/src/test/groovy/org/ajoberstar/grgit/operation/LogOpSpec.groovy
@@ -34,7 +34,7 @@ class LogOpSpec extends SimpleGitOpSpec {
     grgit.checkout(branch: 'master')
     def jgitId = JGitUtil.resolveObject(grgit.repository, commits[2].id)
     def mergeCommit = grgit.repository.jgit.merge().include(jgitId).setStrategy(MergeStrategy.OURS).call().newHead
-    commits << JGitUtil.convertCommit(mergeCommit)
+    commits << JGitUtil.convertCommit(grgit.repository, mergeCommit)
 
     testFile1 << '4'
     grgit.add(patterns: ['.'])

--- a/src/test/groovy/org/ajoberstar/grgit/util/JGitUtilSpec.groovy
+++ b/src/test/groovy/org/ajoberstar/grgit/util/JGitUtilSpec.groovy
@@ -97,6 +97,7 @@ class JGitUtilSpec extends Specification {
     ZonedDateTime commitTime = ZonedDateTime.ofInstant(instant, zone)
     Commit expectedCommit = new Commit(
       ObjectId.toString(commits[1]),
+      ObjectId.toString(commits[1])[0..6],
       [ObjectId.toString(commits[0])],
       person,
       person,
@@ -105,7 +106,7 @@ class JGitUtilSpec extends Specification {
       'second commit'
     )
     expect:
-    def result = JGitUtil.convertCommit(commits[1])
+    def result = JGitUtil.convertCommit(repo, commits[1])
     result == expectedCommit
     result.date.toInstant() == commitTime.toInstant()
   }
@@ -119,7 +120,7 @@ class JGitUtilSpec extends Specification {
     and:
     ZonedDateTime after = ZonedDateTime.now().plusSeconds(2)
     then:
-    tag.commit == JGitUtil.convertCommit(commits[0])
+    tag.commit == JGitUtil.convertCommit(repo, commits[0])
     tag.tagger == person
     tag.fullName == 'refs/tags/v1.0.0'
     tag.fullMessage == 'first tag\ntesting'
@@ -137,7 +138,7 @@ class JGitUtilSpec extends Specification {
     and:
     ZonedDateTime after = ZonedDateTime.now().plusSeconds(2)
     then:
-    tag.commit == JGitUtil.convertCommit(commits[0])
+    tag.commit == JGitUtil.convertCommit(repo, commits[0])
     tag.tagger == null
     tag.fullName == 'refs/tags/v2.0.0'
     tag.fullMessage == null
@@ -154,7 +155,7 @@ class JGitUtilSpec extends Specification {
     and:
     ZonedDateTime after = ZonedDateTime.now().plusSeconds(2)
     then:
-    tag.commit == JGitUtil.convertCommit(commits[0])
+    tag.commit == JGitUtil.convertCommit(repo, commits[0])
     tag.tagger == person
     tag.fullName == 'refs/tags/v1.1.0'
     tag.fullMessage == 'testing'


### PR DESCRIPTION
JGit provides a method that ensures uniqueness. This is safer than the
old approach that just substringed. That option is still around, but
deprecated.

This fixes #238.