### PR TITLE
Consitient parameter naming

### DIFF
--- a/docs/content/grgit-open.adoc
+++ b/docs/content/grgit-open.adoc
@@ -16,7 +16,7 @@ grgit.open()
 
 [source, groovy]
 ----
-grgit.open(dir: <path>, currentDir: <path>, creds: <credentials>)
+grgit.open(dir: <path>, currentDir: <path>, credentials: <credentials>)
 ----
 
 [source, groovy]
@@ -38,7 +38,7 @@ Returns a link:http://ajoberstar.org/grgit/docs/grgit-core/groovydoc/org/ajobers
 
 dir:: (`Object`, default `null`) The directory the repository is in. Can be a `File`, `Path`, or `String`.
 currentDir:: (`Object`, default `null`) The directory to start searching for the repository from. Can be a `File`, `Path`, or `String`.
-creds:: (`Credentials`, default `null`) An instance of link:http://ajoberstar.org/grgit/docs/grgit-core/groovydoc/org/ajoberstar/grgit/Credentials.html[Credentials] containing username/password to be used in operations that require authentication. See link:grgit-authentication.html[grgit-authentication] for preferred ways to configure this.
+credentials:: (`Credentials`, default `null`) An instance of link:http://ajoberstar.org/grgit/docs/grgit-core/groovydoc/org/ajoberstar/grgit/Credentials.html[Credentials] containing username/password to be used in operations that require authentication. See link:grgit-authentication.html[grgit-authentication] for preferred ways to configure this.
 
 == Examples
 

--- a/docs/content/grgit-open.adoc
+++ b/docs/content/grgit-open.adoc
@@ -24,7 +24,7 @@ grgit.open(dir: <path>, currentDir: <path>, credentials: <credentials>)
 grgit.open {
   dir = <path>
   currentDir = <path>
-  creds = <credentals>
+  credentials = <credentals>
 }
 ----
 

--- a/grgit-core/src/main/groovy/org/ajoberstar/grgit/auth/TransportOpUtil.groovy
+++ b/grgit-core/src/main/groovy/org/ajoberstar/grgit/auth/TransportOpUtil.groovy
@@ -26,18 +26,18 @@ final class TransportOpUtil {
   /**
    * Configures the given transport command with the given credentials.
    * @param cmd the command to configure
-   * @param creds the hardcoded credentials to use, if not {@code null}
+   * @param credentials the hardcoded credentials to use, if not {@code null}
    */
-  static void configure(TransportCommand cmd, Credentials creds) {
+  static void configure(TransportCommand cmd, Credentials credentials) {
     AuthConfig config = AuthConfig.fromSystem()
-    cmd.credentialsProvider = determineCredentialsProvider(config, creds)
+    cmd.credentialsProvider = determineCredentialsProvider(config, credentials)
   }
 
-  private static CredentialsProvider determineCredentialsProvider(AuthConfig config, Credentials creds) {
+  private static CredentialsProvider determineCredentialsProvider(AuthConfig config, Credentials credentials) {
     Credentials systemCreds = config.hardcodedCreds
-    if (creds?.populated) {
+    if (credentials?.populated) {
       logger.info('using hardcoded credentials provided programmatically')
-      return new UsernamePasswordCredentialsProvider(creds.username, creds.password)
+      return new UsernamePasswordCredentialsProvider(credentials.username, credentials.password)
     } else if (systemCreds?.populated) {
       logger.info('using hardcoded credentials from system properties')
       return new UsernamePasswordCredentialsProvider(systemCreds.username, systemCreds.password)

--- a/grgit-core/src/main/groovy/org/ajoberstar/grgit/operation/CloneOp.groovy
+++ b/grgit-core/src/main/groovy/org/ajoberstar/grgit/operation/CloneOp.groovy
@@ -58,7 +58,7 @@ class CloneOp implements Callable<Grgit> {
   /**
    * The username and credentials to use when checking out the
    * repository and for subsequent remote operations on the
-   * repository. This is only needed if hardcoded creds
+   * repository. This is only needed if hardcoded credentials
    * should be used.
    * @see {@link org.ajoberstar.gradle.auth.AuthConfig}
    */

--- a/grgit-core/src/main/groovy/org/ajoberstar/grgit/operation/OpenOp.groovy
+++ b/grgit-core/src/main/groovy/org/ajoberstar/grgit/operation/OpenOp.groovy
@@ -65,4 +65,14 @@ class OpenOp implements Callable<Grgit> {
       return new Grgit(repo)
     }
   }
+
+  @Deprecated
+  Credentials getCreds(){
+    return credentials
+  }
+
+  @Deprecated
+  void setCreds(Credentials creds){
+    this.credentials = creds
+  }
 }

--- a/grgit-core/src/main/groovy/org/ajoberstar/grgit/operation/OpenOp.groovy
+++ b/grgit-core/src/main/groovy/org/ajoberstar/grgit/operation/OpenOp.groovy
@@ -22,7 +22,7 @@ class OpenOp implements Callable<Grgit> {
   /**
    * Hardcoded credentials to use for remote operations.
    */
-  Credentials creds
+  Credentials credentials
 
   /**
    * The directory to open the repository from. Incompatible
@@ -43,7 +43,7 @@ class OpenOp implements Callable<Grgit> {
       throw new IllegalArgumentException('Cannot use both dir and currentDir.')
     } else if (dir) {
       def dirFile = CoercionUtil.toFile(dir)
-      def repo = new Repository(dirFile, Git.open(dirFile), creds)
+      def repo = new Repository(dirFile, Git.open(dirFile), credentials)
       return new Grgit(repo)
     } else {
       FileRepositoryBuilder builder = new FileRepositoryBuilder()
@@ -61,7 +61,7 @@ class OpenOp implements Callable<Grgit> {
 
       FileRepository jgitRepo = builder.build()
       Git jgit = new Git(jgitRepo)
-      Repository repo = new Repository(jgitRepo.directory, jgit, creds)
+      Repository repo = new Repository(jgitRepo.directory, jgit, credentials)
       return new Grgit(repo)
     }
   }

--- a/grgit-core/src/test/groovy/org/ajoberstar/grgit/operation/OpenOpSpec.groovy
+++ b/grgit-core/src/test/groovy/org/ajoberstar/grgit/operation/OpenOpSpec.groovy
@@ -1,5 +1,7 @@
 package org.ajoberstar.grgit.operation
 
+import org.ajoberstar.grgit.Credentials
+
 import java.nio.file.Files
 
 import org.ajoberstar.grgit.Commit
@@ -134,5 +136,19 @@ class OpenOpSpec extends SimpleGitOpSpec {
     opened.close()
     then:
     opened.repository.rootDir.deleteDir()
+  }
+
+  def 'credentials as param name should work'() {
+    when:
+    Grgit opened = Grgit.open(dir: repoDir('.'), credentials: new Credentials())
+    then:
+    opened.head() == commit
+  }
+
+  def 'creds as param name should work'() {
+    when:
+    Grgit opened = Grgit.open(dir: repoDir('.'), creds: new Credentials())
+    then:
+    opened.head() == commit
   }
 }


### PR DESCRIPTION
I've made the naming of the Credentials parameter consitient between open and clone methods.