### PR TITLE
Replace Consumer with HasImplicitReceiver support

### DIFF
--- a/grgit-core/src/main/groovy/org/ajoberstar/grgit/Configurable.groovy
+++ b/grgit-core/src/main/groovy/org/ajoberstar/grgit/Configurable.groovy
@@ -1,0 +1,9 @@
+package org.ajoberstar.grgit
+
+import org.ajoberstar.grgit.internal.AnnotateAtRuntime
+
+@FunctionalInterface
+@AnnotateAtRuntime(annotations = "org.gradle.api.HasImplicitReceiver")
+interface Configurable<T> {
+  void configure(T t)
+}

--- a/grgit-core/src/main/groovy/org/ajoberstar/grgit/internal/AnnotateAtRuntime.java
+++ b/grgit-core/src/main/groovy/org/ajoberstar/grgit/internal/AnnotateAtRuntime.java
@@ -1,0 +1,15 @@
+package org.ajoberstar.grgit.internal;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.codehaus.groovy.transform.GroovyASTTransformationClass;
+
+@Retention(RetentionPolicy.SOURCE)
+@Target(ElementType.TYPE)
+@GroovyASTTransformationClass("org.ajoberstar.grgit.internal.AnnotateAtRuntimeASTTransformation")
+public @interface AnnotateAtRuntime {
+  String[] annotations() default {};
+}

--- a/grgit-core/src/main/groovy/org/ajoberstar/grgit/internal/AnnotateAtRuntimeASTTransformation.java
+++ b/grgit-core/src/main/groovy/org/ajoberstar/grgit/internal/AnnotateAtRuntimeASTTransformation.java
@@ -1,0 +1,33 @@
+package org.ajoberstar.grgit.internal;
+
+import java.util.List;
+
+import org.codehaus.groovy.ast.ASTNode;
+import org.codehaus.groovy.ast.AnnotatedNode;
+import org.codehaus.groovy.ast.AnnotationNode;
+import org.codehaus.groovy.ast.ClassNode;
+import org.codehaus.groovy.control.SourceUnit;
+import org.codehaus.groovy.transform.AbstractASTTransformation;
+import org.codehaus.groovy.transform.GroovyASTTransformation;
+
+@GroovyASTTransformation
+public final class AnnotateAtRuntimeASTTransformation extends AbstractASTTransformation {
+  @Override
+  public void visit(ASTNode[] nodes, SourceUnit source) {
+    AnnotationNode annotation = (AnnotationNode) nodes[0];
+    AnnotatedNode parent = (AnnotatedNode) nodes[1];
+
+    ClassNode clazz = (ClassNode) parent;
+    List<String> annotations = getMemberList(annotation, "annotations");
+    for (String name : annotations) {
+      // !!! UGLY HACK !!!
+      // Groovy won't think the class is an annotation when creating a ClassNode just based on the name.
+      // Instead, we create a node based on an interface and then overwrite the name to get the interface
+      // we actually want.
+      ClassNode base = new ClassNode(FunctionalInterface.class);
+      base.setName(name);
+
+      clazz.addAnnotation(new AnnotationNode(base));
+    }
+  }
+}

--- a/grgit-core/src/main/groovy/org/ajoberstar/grgit/internal/OpSyntax.groovy
+++ b/grgit-core/src/main/groovy/org/ajoberstar/grgit/internal/OpSyntax.groovy
@@ -1,7 +1,8 @@
 package org.ajoberstar.grgit.internal
 
 import java.util.concurrent.Callable
-import java.util.function.Consumer
+
+import org.ajoberstar.grgit.Configurable
 
 class OpSyntax {
   static def noArgOperation(Class<Callable> opClass, Object[] classArgs) {
@@ -19,9 +20,9 @@ class OpSyntax {
     return op.call()
   }
 
-  static def consumerOperation(Class<Callable> opClass, Object[] classArgs, Consumer arg) {
+  static def samOperation(Class<Callable> opClass, Object[] classArgs, Configurable arg) {
     def op = opClass.newInstance(classArgs)
-    arg.accept(op)
+    arg.configure(op)
     return op.call()
   }
 

--- a/grgit-core/src/main/groovy/org/ajoberstar/grgit/internal/WithOperationsASTTransformation.java
+++ b/grgit-core/src/main/groovy/org/ajoberstar/grgit/internal/WithOperationsASTTransformation.java
@@ -7,9 +7,9 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Consumer;
 
 import groovy.lang.Closure;
+import org.ajoberstar.grgit.Configurable;
 import org.codehaus.groovy.ast.ASTNode;
 import org.codehaus.groovy.ast.AnnotatedNode;
 import org.codehaus.groovy.ast.AnnotationNode;
@@ -60,7 +60,7 @@ public class WithOperationsASTTransformation extends AbstractASTTransformation {
 
     targetClass.addMethod(makeNoArgMethod(targetClass, opName, opClass, opReturn, isStatic));
     targetClass.addMethod(makeMapMethod(targetClass, opName, opClass, opReturn, isStatic));
-    targetClass.addMethod(makeConsumerMethod(targetClass, opName, opClass, opReturn, isStatic));
+    targetClass.addMethod(makeSamMethod(targetClass, opName, opClass, opReturn, isStatic));
     targetClass.addMethod(makeClosureMethod(targetClass, opName, opClass, opReturn, isStatic));
   }
 
@@ -100,8 +100,8 @@ public class WithOperationsASTTransformation extends AbstractASTTransformation {
     return new MethodNode(opName, modifiers(isStatic), opReturn, parms, new ClassNode[] {}, code);
   }
 
-  private MethodNode makeConsumerMethod(ClassNode targetClass, String opName, ClassNode opClass, ClassNode opReturn, boolean isStatic) {
-    ClassNode parmType = classFromType(Consumer.class);
+  private MethodNode makeSamMethod(ClassNode targetClass, String opName, ClassNode opClass, ClassNode opReturn, boolean isStatic) {
+    ClassNode parmType = classFromType(Configurable.class);
     GenericsType[] generics = new GenericsType[] {new GenericsType(opClass)};
     parmType.setGenericsTypes(generics);
     Parameter[] parms = new Parameter[] {new Parameter(parmType, "arg")};
@@ -109,7 +109,7 @@ public class WithOperationsASTTransformation extends AbstractASTTransformation {
     Statement code = new ExpressionStatement(
         new StaticMethodCallExpression(
             classFromType(OpSyntax.class),
-            "consumerOperation",
+            "samOperation",
             new ArgumentListExpression(
                 new ClassExpression(opClass),
                 new ArrayExpression(


### PR DESCRIPTION
Gradle usage from Groovy build scripts can use the Closure methods
and get a clean delegation:

    Grgit.open { currentDir = 'somewhere' }

From Kotlin build scripts, they fell back to the Consumer variant, but
that required the receiver (roughly equivalent in this context to the
Groovy delegate) to be explicitly referenced:

    Grgit.open { it.currentDir = 'somewhere' }

Using an interface with @HasImplicitReceiver allows for use like the
above Groovy usage.

Gradle provides the Action interface to meet this need, but in order to
preserve some independence from Gradle's API, since grgit is meant to be
generically a Groovy Git binding, we can't have the Action class or the
HasImplicitReceiver annotation on the classpath during compile.

We're doing a workaround at the moment that adds the annotation as part
of an AST transformation.

This change was provided by Alex Saveau.

I don't intend Kotlin usage to be a core supported feature of this
project, so this is just a best effort for now. If it ever requires more
extensive changes or breaks, I will favor removing it to making any
significant changes.