### PR TITLE
Use findRef() instead of getRef()

### DIFF
--- a/grgit-core/src/main/groovy/org/ajoberstar/grgit/util/JGitUtil.groovy
+++ b/grgit-core/src/main/groovy/org/ajoberstar/grgit/util/JGitUtil.groovy
@@ -127,7 +127,7 @@ class JGitUtil {
    * @return the resolved tag
    */
   static Tag resolveTag(Repository repo, String name) {
-    Ref ref = repo.jgit.repository.getRef(name)
+    Ref ref = repo.jgit.repository.findRef(name)
     return resolveTag(repo, ref)
   }
 


### PR DESCRIPTION
I found the method which still use ```getRef()``` deprecated in JGit. 

