### PR TITLE
Added rename tracking to ShowOp (#273).

### DIFF
--- a/grgit-core/src/main/groovy/org/ajoberstar/grgit/CommitDiff.groovy
+++ b/grgit-core/src/main/groovy/org/ajoberstar/grgit/CommitDiff.groovy
@@ -18,6 +18,8 @@ class CommitDiff {
 
   Set<String> renamed = []
 
+  Map<String,String> renamings = [:]
+
   /**
    * Gets all changed files.
    * @return all changed files

--- a/grgit-core/src/main/groovy/org/ajoberstar/grgit/operation/ShowOp.groovy
+++ b/grgit-core/src/main/groovy/org/ajoberstar/grgit/operation/ShowOp.groovy
@@ -61,7 +61,8 @@ class ShowOp implements Callable<CommitDiff> {
         copied: entriesByType[ChangeType.COPY].collect { it.newPath },
         modified: entriesByType[ChangeType.MODIFY].collect { it.newPath },
         removed: entriesByType[ChangeType.DELETE].collect { it.oldPath },
-        renamed: entriesByType[ChangeType.RENAME].collect { it.newPath }
+        renamed: entriesByType[ChangeType.RENAME].collect { it.newPath },
+        renamings: entriesByType[ChangeType.RENAME]?.collectEntries { [(it.oldPath): it.newPath] } ?: [:]
       )
     } else {
       walk.addTree(commitId.tree)

--- a/grgit-core/src/test/groovy/org/ajoberstar/grgit/operation/ShowOpSpec.groovy
+++ b/grgit-core/src/test/groovy/org/ajoberstar/grgit/operation/ShowOpSpec.groovy
@@ -91,7 +91,8 @@ class ShowOpSpec extends SimpleGitOpSpec {
     expect:
     grgit.show(commit: renameCommit) == new CommitDiff(
       commit: renameCommit,
-      renamed: ['mammoth.txt']
+      renamed: ['mammoth.txt'],
+      renamings: [('elephant.txt'):'mammoth.txt']
     )
   }
 


### PR DESCRIPTION
I went for a rather succinct naming - hope that's allright.

Without the explicit null-handling the other ShopOp-testcases failed with an NPE; however I do not know why only for this particular line (maybe a slightly different handling of collectEntries vs. collect?).