### PR TITLE
DescribeOp: Add the "always" option

### DIFF
--- a/docs/content/grgit-describe.adoc
+++ b/docs/content/grgit-describe.adoc
@@ -38,6 +38,7 @@ Describe only shows annotated tags. For more information about creating annotate
 == Options
 
 commit:: (`Object`, default `null`) Commit-ish object names to describe. Defaults to HEAD if omitted. For a more complete list of ways to spell commit names, see link:grgit-resolve.html[grgit-resolve] (specifically the `toCommit` method).
+always:: (`boolean`, default `false`) When `true`, always describe a commit in some way and fall back to a uniquely abbreviated commit if no tags match.
 longDescr:: (`boolean`, default `false`) Always output the long format (the tag, the number of commits and the abbreviated commit name) even when it matches a tag. This is useful when you want to see parts of the commit object name in "describe" output, even when the commit in question happens to be a tagged version. Instead of just emitting the tag name, it will describe such a commit as v1.2-0-gdeadbee (0th commit since tag v1.2 that points at object deadbee…​.).
 tags:: (`boolean`, default `false`) Instead of using only the annotated tags, use any tag found in `refs/tags` namespace. This option enables matching a lightweight (non-annotated) tag.
 match:: (`List<String>`, default `[]`) Only consider tags matching the given glob(7) pattern, excluding the "refs/tags/" prefix. This can be used to avoid leaking private tags from the repository. If multiple patterns are given they will be accumulated, and tags matching any of the patterns will be considered.

--- a/grgit-core/src/main/groovy/org/ajoberstar/grgit/operation/DescribeOp.groovy
+++ b/grgit-core/src/main/groovy/org/ajoberstar/grgit/operation/DescribeOp.groovy
@@ -27,6 +27,11 @@ class DescribeOp implements Callable<String> {
   Object commit
 
   /**
+   * Whether to show a uniquely abbreviated commit if no tags match.
+   */
+  boolean always
+
+  /**
    * Whether to always use long output format or not.
    */
   boolean longDescr
@@ -46,6 +51,7 @@ class DescribeOp implements Callable<String> {
     if (commit) {
       cmd.setTarget(new ResolveService(repo).toRevisionString(commit))
     }
+    cmd.setAlways(always)
     cmd.setLong(longDescr)
     cmd.setTags(tags)
     if (match) {

--- a/grgit-core/src/test/groovy/org/ajoberstar/grgit/operation/DescribeOpSpec.groovy
+++ b/grgit-core/src/test/groovy/org/ajoberstar/grgit/operation/DescribeOpSpec.groovy
@@ -5,12 +5,23 @@ import org.ajoberstar.grgit.fixtures.SimpleGitOpSpec
 class DescribeOpSpec extends SimpleGitOpSpec {
   def setup() {
     grgit.commit(message:'initial commit')
-    grgit.tag.add(name:'initial')
+
+    grgit.commit(message:'second commit')
+    grgit.tag.add(name:'second')
+
     grgit.commit(message:'another commit')
     grgit.tag.add(name:'another')
+
     grgit.commit(message:'other commit')
     grgit.tag.add(name:'other', annotate: false)
+  }
 
+  def 'without tag'() {
+    given:
+    grgit.reset(commit: 'HEAD~3', mode: 'hard')
+    expect:
+    grgit.describe() == null
+    grgit.describe(always: true) == grgit.head().abbreviatedId
   }
 
   def 'with tag'() {
@@ -35,7 +46,7 @@ class DescribeOpSpec extends SimpleGitOpSpec {
     grgit.add(patterns:['1.txt'])
     grgit.commit(message:  'another commit')
     expect:
-    grgit.describe(commit: 'HEAD~3') == 'initial'
+    grgit.describe(commit: 'HEAD~3') == 'second'
   }
 
   def 'with long description'() {
@@ -50,6 +61,6 @@ class DescribeOpSpec extends SimpleGitOpSpec {
 
   def 'with match'() {
     expect:
-    grgit.describe(match: ['initial*']).startsWith('initial-2-')
+    grgit.describe(match: ['second*']).startsWith('second-2-')
   }
 }


### PR DESCRIPTION
The "always" option is natively supported in JGit 5.4.0 and above.