### PR TITLE
Closes #145

### DIFF
--- a/docs/content/grgit-clone.adoc
+++ b/docs/content/grgit-clone.adoc
@@ -11,8 +11,9 @@ grgit-clone - Clone a repository into a new directory
 
 [source, groovy]
 ----
-grgit.clone(dir: <path>, uri: <path or uri>, remote: <name>, bare: <boolean>,
-  checkout: <boolean>, refToCheckout: <name>, credentials: <credentials>)
+grgit.clone(dir: <path>, uri: <path or uri>, remote: <name>, all: <boolean>,
+  bare: <boolean>, branches: <full refs>, checkout: <boolean>,
+  refToCheckout: <name>, credentials: <credentials>)
 ----
 
 [source, groovy]
@@ -21,7 +22,9 @@ grgit.clone {
   dir = <path>
   uri = <path or uri>
   remote = <name>
+  all = <boolean>
   bare = <boolean>
+  branches = <full refs>
   checkout = <boolean>
   refToCheckout = <name>
   credentials = <credentials>
@@ -43,7 +46,9 @@ Returns a link:http://ajoberstar.org/grgit/docs/grgit-core/groovydoc/org/ajobers
 dir:: (`Object`, default `null`) The directory the repository should be cloned into. Can be a `File`, `Path`, or `String`.
 uri:: (`String`, default `null`) The URI to the repository to be cloned.
 remote:: (`String`, default `origin`) Instead of using the remote name `origin` to keep track of the upstream repository, use `<name>`.
+all:: (`boolean`, default `false`) Clone all branches.
 bare:: (`boolean`, default `false`) Create a bare repository.
+branches:: (`List<String>`, `[]`) Select full refs to use with `all = false`.
 checkout:: (`boolean`, default `true`) Set to `false` to skip checking out a `HEAD`.
 refToCheckout:: (`String`, default `null`) Instead of pointing the newly created `HEAD` to the branch pointed to by the cloned repository’s `HEAD`, point to `<name>` branch instead. In a non-bare repository, this is the branch that will be checked out. This can also take tags and detaches the `HEAD` at that commit in the resulting repository.
 credentials:: (`Credentials`, default `null`) An instance of link:http://ajoberstar.org/grgit/docs/grgit-core/groovydoc/org/ajoberstar/grgit/Credentials.html[Credentials] containing username/password to be used in operations that require authentication. See link:grgit-authentication.html[grgit-authentication] for preferred ways to configure this.

--- a/grgit-core/src/main/groovy/org/ajoberstar/grgit/Grgit.groovy
+++ b/grgit-core/src/main/groovy/org/ajoberstar/grgit/Grgit.groovy
@@ -122,7 +122,7 @@ class Grgit implements AutoCloseable {
    */
   final TagService tag
 
-  private Grgit(Repository repository) {
+  Grgit(Repository repository) {
     this.repository = repository
     this.branch = new BranchService(repository)
     this.remote = new RemoteService(repository)

--- a/grgit-core/src/main/groovy/org/ajoberstar/grgit/operation/CloneOp.groovy
+++ b/grgit-core/src/main/groovy/org/ajoberstar/grgit/operation/CloneOp.groovy
@@ -38,10 +38,18 @@ class CloneOp implements Callable<Grgit> {
   String remote = 'origin'
 
   /**
+   * {@code true} when all branches have to be fetched,
+   * {@code false} (the default) otherwise.
+   */
+  boolean all = false
+
+  /**
    * {@code true} if the resulting repository should be bare,
    * {@code false} (the default) otherwise.
    */
   boolean bare = false
+
+  List<String> branches = []
 
   /**
    * {@code true} (the default) if a working tree should be checked out,
@@ -60,7 +68,7 @@ class CloneOp implements Callable<Grgit> {
    * repository and for subsequent remote operations on the
    * repository. This is only needed if hardcoded credentials
    * should be used.
-   * @see {@link org.ajoberstar.gradle.auth.AuthConfig}
+   * @see {@link org.ajoberstar.grgit.auth.AuthConfig}
    */
   Credentials credentials
 
@@ -73,11 +81,13 @@ class CloneOp implements Callable<Grgit> {
     TransportOpUtil.configure(cmd, credentials)
 
     cmd.directory = CoercionUtil.toFile(dir)
-    cmd.uri = uri
+    cmd.setURI(uri)
     cmd.remote = remote
     cmd.bare = bare
     cmd.noCheckout = !checkout
     if (refToCheckout) { cmd.branch = refToCheckout }
+    if (all) cmd.cloneAllBranches = all
+    if (!branches.isEmpty()) cmd.branchesToClone = branches
 
     Git jgit = cmd.call()
     Repository repo = new Repository(CoercionUtil.toFile(dir), jgit, credentials)

--- a/grgit-core/src/main/groovy/org/ajoberstar/grgit/operation/CloneOp.groovy
+++ b/grgit-core/src/main/groovy/org/ajoberstar/grgit/operation/CloneOp.groovy
@@ -49,6 +49,10 @@ class CloneOp implements Callable<Grgit> {
    */
   boolean bare = false
 
+  /**
+   * The list of full refs to be cloned when {@code all = false}. Defaults to
+   * all available branches.
+   */
   List<String> branches = []
 
   /**

--- a/grgit-core/src/test/groovy/org/ajoberstar/grgit/operation/CloneOpSpec.groovy
+++ b/grgit-core/src/test/groovy/org/ajoberstar/grgit/operation/CloneOpSpec.groovy
@@ -117,6 +117,34 @@ class CloneOpSpec extends MultiGitOpSpec {
     GitTestUtil.remotes(grgit) == ['origin']
   }
 
+  def 'clone with all true works'() {
+    when:
+    def grgit = Grgit.clone(dir: repoDir, uri: remoteUri, all: true)
+    then:
+    grgit.head() == remoteGrgit.resolve.toCommit('master')
+    GitTestUtil.branches(grgit).findAll(remoteBranchesFilter).collect(lastName) == GitTestUtil.branches(remoteGrgit).collect(lastName)
+    GitTestUtil.branches(grgit).findAll(localBranchesFilter).collect(lastName) == ['master']
+  }
+
+  def 'clone with all false has the same effect as all true'() {
+    when:
+    def grgit = Grgit.clone(dir: repoDir, uri: remoteUri, all: false)
+    then:
+    grgit.head() == remoteGrgit.resolve.toCommit('master')
+    GitTestUtil.branches(grgit).findAll(remoteBranchesFilter).collect(lastName) == GitTestUtil.branches(remoteGrgit).collect(lastName)
+    GitTestUtil.branches(grgit).findAll(localBranchesFilter).collect(lastName) == ['master']
+  }
+
+  def 'clone with all false and explicitly set branches works'() {
+    when:
+    def branches = ['refs/heads/master', 'refs/heads/branch1']
+    def grgit = Grgit.clone(dir: repoDir, uri: remoteUri, all: false, branches: branches)
+    then:
+    grgit.head() == remoteGrgit.resolve.toCommit('master')
+    GitTestUtil.branches(grgit).findAll(remoteBranchesFilter).collect(lastName).sort() == ['master', 'branch1'].sort()
+    GitTestUtil.branches(grgit).findAll(localBranchesFilter).collect(lastName) == ['master']
+  }
+
   def 'cloned repo can be deleted'() {
     given:
     def grgit = Grgit.clone(dir: repoDir, uri: remoteUri, refToCheckout: 'refs/heads/branch2')


### PR DESCRIPTION
There is probably a nicer way to indicate that `all = false` has no effect unless a list of branches is provided, and to indicate that full refs are required for `CloneOp#branches`, but I think this is a fairly nice match with the underlying Jgit behavior. I made sure that if `all` or `branches` aren't touched then there is no effect on the Jgit `CloneCommand` - the resulting behavior should be the same as without this patch.